### PR TITLE
Custom element support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,13 @@
 	},
 	"typings": "./dist/umd/dojo-app.d.ts",
 	"peerDependencies": {
+		"@reactivex/rxjs": "5.0.0-beta.6",
 		"dojo-actions": "^2.0.0-alpha.4",
 		"dojo-compose": "^2.0.0-beta.5",
-		"dojo-core": "^2.0.0-alpha.7"
+		"dojo-core": "^2.0.0-alpha.7",
+		"dojo-widgets": "^2.0.0-alpha.3",
+		"immutable": "^3.8.1",
+		"maquette": "^2.3.2"
 	},
 	"devDependencies": {
 		"codecov.io": "0.1.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"dojo-actions": "^2.0.0-alpha.4",
 		"dojo-compose": "^2.0.0-beta.5",
 		"dojo-core": "^2.0.0-alpha.7",
+		"dojo-dom": "^2.0.0-alpha.1",
 		"dojo-widgets": "^2.0.0-alpha.3",
 		"immutable": "^3.8.1",
 		"maquette": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"grunt-typings": ">=0.1.5",
 		"intern": "^3.2.3",
 		"istanbul": "^0.4.3",
+		"jsdom": "^9.2.1",
 		"remap-istanbul": "^0.6.4",
 		"tslint": "^3.11.0",
 		"typescript": "^1.8.10"

--- a/src/_factories.ts
+++ b/src/_factories.ts
@@ -93,6 +93,18 @@ function isInstance(value: any): value is Instance {
 	return value && typeof value === 'object';
 }
 
+/**
+ * Resolve a factory for an action, store or widget.
+ *
+ * Definitions have either `instance` or `factory` fields. These may be module identifiers. If necessary resolve the
+ * module identifier, then if an instance was defined create a wrapper function that can act as a factory for
+ * that instance.
+ *
+ * @param type What type of factory needs to be resolved
+ * @param definition Definition of the action, store or widget that is resolved
+ * @param resolveMid Function to asynchronously resolve a module identifier
+ * @return A promise for the factory. Rejects if the resolved module does not export an appropriate default
+ */
 function resolveFactory(type: 'action', definition: ActionDefinition, resolveMid: ResolveMid): Promise<ActionFactory>;
 function resolveFactory(type: 'store', definition: StoreDefinition, resolveMid: ResolveMid): Promise<StoreFactory>;
 function resolveFactory(type: 'widget', definition: WidgetDefinition, resolveMid: ResolveMid): Promise<WidgetFactory>;

--- a/src/_realizeCustomElements.ts
+++ b/src/_realizeCustomElements.ts
@@ -12,6 +12,45 @@ import {
 	WidgetLike
 } from './createApp';
 
+const reservedNames = new Set([
+	// According to <https://www.w3.org/TR/custom-elements/#valid-custom-element-name>.
+	'annotation-xml',
+	'color-profile',
+	'font-face',
+	'font-face-src',
+	'font-face-uri',
+	'font-face-format',
+	'font-face-name',
+	'missing-glyph',
+	// These are reserved by this module.
+	'widget-instance',
+	'widget-projector'
+]);
+
+// According to <https://www.w3.org/TR/custom-elements/#valid-custom-element-name>.
+export function isValidName(name: string): boolean {
+	if (!/^[a-z]/.test(name)) { // Names must start with a lowercase ASCII letter
+		return false;
+	}
+
+	if (name.indexOf('-') === -1) { // Names must contain at least one hyphen
+		return false;
+	}
+
+	if (/[A-Z]/.test(name)) { // Names must not include uppercase ASCII letters
+		return false;
+	}
+
+	if (reservedNames.has(name)) { // Reserved names must not be used.
+		return false;
+	}
+
+	// Assume name does not contain other invalid characters.
+	// TODO: Are the above rules sufficiently exclusive given the allowed PCENChar characters in the
+	// <https://www.w3.org/TR/custom-elements/#valid-custom-element-name> specification?
+	return true;
+}
+
 // <https://www.w3.org/TR/custom-elements/#look-up-a-custom-element-definition> doesn't define *how* names
 // are to be compared. Additionally browsers and document modes differ in the case used for Element#tagName
 // values. Lowercasing the name is the most compatible solution. This is also the approach taken by the
@@ -28,11 +67,11 @@ interface CustomElement {
 	widget?: WidgetLike;
 }
 
-function isCustomElement(name: string): boolean {
-	return name === 'widget-projector' || name === 'widget-instance';
+function isCustomElement(registry: CombinedRegistry, name: string): boolean {
+	return name === 'widget-projector' || name === 'widget-instance' || registry.hasCustomElementFactory(name);
 }
 
-function getCustomElementsByWidgetProjector(root: Element): CustomElement[] {
+function getCustomElementsByWidgetProjector(registry: CombinedRegistry, root: Element): CustomElement[] {
 	const allElements: Element[] = arrayFrom(root.getElementsByTagName('*'));
 	allElements.unshift(root); // Be inclusive!
 
@@ -41,12 +80,12 @@ function getCustomElementsByWidgetProjector(root: Element): CustomElement[] {
 		let name: string;
 
 		const tagName = normalizeName(element.tagName);
-		if (isCustomElement(tagName)) {
+		if (isCustomElement(registry, tagName)) {
 			name = tagName;
 		}
 		else {
 			const attrIs = normalizeName(element.getAttribute('is') || '');
-			if (attrIs !== '' && isCustomElement(attrIs)) {
+			if (attrIs !== '' && isCustomElement(registry, attrIs)) {
 				name = attrIs;
 			}
 		}
@@ -127,6 +166,8 @@ export default function realizeCustomElements(registry: CombinedRegistry, root: 
 	const immediatePlaceholderLookup = new Map<Projector, CustomElement[]>();
 	// Projector instances for each widget projector.
 	const projectors: Projector[] = [];
+	// Widgets that are created during realization (not registered instances).
+	const managedWidgets: WidgetLike[] = [];
 
 	// Return a new promise here so API errors can be thrown in the executor, while still resulting in a
 	// promise rejection.
@@ -134,7 +175,7 @@ export default function realizeCustomElements(registry: CombinedRegistry, root: 
 		// Flat list of all widgets that are being loaded.
 		const loadedWidgets: Promise<WidgetLike>[] = [];
 
-		const widgetProjectors = getCustomElementsByWidgetProjector(root);
+		const widgetProjectors = getCustomElementsByWidgetProjector(registry, root);
 		for (const { children, element: root } of widgetProjectors) {
 			const projector = createProjector({ root });
 			immediatePlaceholderLookup.set(projector, children);
@@ -144,12 +185,23 @@ export default function realizeCustomElements(registry: CombinedRegistry, root: 
 			let processing = [children];
 			while (processing.length > 0) {
 				for (const custom of processing.shift()) {
-					// TODO: This currently assumes `is === 'widget-instance'`
-					const promise = resolveWidgetInstance(registry, custom.element).then((widget) => {
+					const isWidgetInstance = custom.name === 'widget-instance';
+					const promise = isWidgetInstance ?
+						resolveWidgetInstance(registry, custom.element) :
+						Promise.resolve(registry.getCustomElementFactory(custom.name)());
+
+					loadedWidgets.push(promise.then((widget) => {
 						// Store the widget for easy access.
-						return custom.widget = widget;
-					});
-					loadedWidgets.push(promise);
+						custom.widget = widget;
+
+						// Widget instances come straight from the registry, but the other widgets were created
+						// whilst realizing the custom elements. These should be managed.
+						if (!isWidgetInstance) {
+							managedWidgets.push(widget);
+						}
+
+						return widget;
+					}));
 
 					if (custom.children.length > 0) {
 						// Ensure the children are processed.
@@ -217,8 +269,9 @@ export default function realizeCustomElements(registry: CombinedRegistry, root: 
 				for (const p of projectors) {
 					p.destroy();
 				}
-				// TODO: Instances from the registry should *not* be destroyed when the returned handle is
-				// destroyed, however instances created on the fly from tag registries *should* be.
+				for (const w of managedWidgets) {
+					w.destroy();
+				}
 			}
 		};
 	});

--- a/src/_realizeCustomElements.ts
+++ b/src/_realizeCustomElements.ts
@@ -1,0 +1,225 @@
+import { from as arrayFrom } from 'dojo-core/array';
+import { Handle } from 'dojo-core/interfaces';
+import Promise from 'dojo-core/Promise';
+import Set from 'dojo-core/Set';
+import Map from 'dojo-core/Map';
+import { place, Position } from 'dojo-dom/dom';
+import { createProjector, Projector } from 'dojo-widgets/projector';
+import { ParentListMixin } from 'dojo-widgets/mixins/createParentListMixin';
+
+import {
+	CombinedRegistry,
+	WidgetLike
+} from './createApp';
+
+// <https://www.w3.org/TR/custom-elements/#look-up-a-custom-element-definition> doesn't define *how* names
+// are to be compared. Additionally browsers and document modes differ in the case used for Element#tagName
+// values. Lowercasing the name is the most compatible solution. This is also the approach taken by the
+// Web Components polyfill:
+// <https://github.com/webcomponents/webcomponentsjs/blob/251f4afedec0ce649728fa1cf22e4fc16bf2bea5/src/CustomElements/register.js#L93>
+export function normalizeName(name: string): string {
+	return name.toLowerCase();
+}
+
+interface CustomElement {
+	children: CustomElement[];
+	element: Element;
+	name: string;
+	widget?: WidgetLike;
+}
+
+function isCustomElement(name: string): boolean {
+	return name === 'widget-projector' || name === 'widget-instance';
+}
+
+function getCustomElementsByWidgetProjector(root: Element): CustomElement[] {
+	const allElements: Element[] = arrayFrom(root.getElementsByTagName('*'));
+	allElements.unshift(root); // Be inclusive!
+
+	const customElements: CustomElement[] = [];
+	for (const element of allElements) {
+		let name: string;
+
+		const tagName = normalizeName(element.tagName);
+		if (isCustomElement(tagName)) {
+			name = tagName;
+		}
+		else {
+			const attrIs = normalizeName(element.getAttribute('is') || '');
+			if (attrIs !== '' && isCustomElement(attrIs)) {
+				name = attrIs;
+			}
+		}
+
+		if (name) {
+			customElements.push({ children: [], element, name });
+		}
+	}
+
+	// A list of trees, reconstructed from the `customElements`.
+	const widgetProjectors: CustomElement[] = [];
+	// Inverse stack of the nodes in the current tree. The deepest node is at the start of the list.
+	const inverseStack: CustomElement[] = [];
+
+	const discardFirstNode = (element: Element) => {
+		if (inverseStack.length === 0) {
+			return false;
+		}
+
+		// Return `true` if the top-most element in the stack does *not* contain `element`.
+		return !(inverseStack[0].element.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_CONTAINED_BY);
+	};
+
+	// `customElements` is a flat list of elements, in document order. Reconstruct a tree structure where each
+	// root is assumed to be a widget projector.
+	for (const custom of customElements) {
+		// Remove nodes from the stack that do not contain the element.
+		while (discardFirstNode(custom.element)) {
+			inverseStack.shift();
+		}
+
+		// Start a new tree if the element is not contained in any existing node.
+		if (inverseStack.length === 0) {
+			// Don't costruct an invalid tree.
+			if (custom.name !== 'widget-projector') {
+				throw new Error('Custom tags must be rooted in a widget-projector');
+			}
+
+			widgetProjectors.push(custom);
+		}
+		// Add the element to the deepest node it is contained by.
+		else {
+			// Don't costruct an invalid tree.
+			if (custom.name === 'widget-projector') {
+				throw new Error('widget-projector cannot contain another widget-projector');
+			}
+
+			inverseStack[0].children.push(custom);
+		}
+
+		// Prepare for the next iteration.
+		inverseStack.unshift(custom);
+	}
+
+	return widgetProjectors;
+}
+
+function resolveWidgetInstance(registry: CombinedRegistry, element: Element): Promise<WidgetLike> {
+	// Resolve the widget instance ID. The `data-widget-id` attribute takes precedence over `id`.
+	const attrWidgetId = element.getAttribute('data-widget-id');
+	const attrId = element.getAttribute('id');
+	const id = attrWidgetId || attrId;
+	if (!id) {
+		throw new Error('Cannot resolve widget for a custom element without \'data-widget-id\' or \'id\' attributes');
+	}
+
+	return registry.getWidget(id);
+}
+
+const noop = () => {};
+
+export default function realizeCustomElements(registry: CombinedRegistry, root: Element): Promise<Handle> {
+	// Bottom up, breadth first queue of custom elements who's children's widgets need to be appended to
+	// their own widget. Combined for all widget projectors.
+	const appendQueue: CustomElement[] = [];
+	// For each projector, track the immediate custom element descendants. These placeholder
+	// elements will be replaced with rendered widgets.
+	const immediatePlaceholderLookup = new Map<Projector, CustomElement[]>();
+	// Projector instances for each widget projector.
+	const projectors: Projector[] = [];
+
+	// Return a new promise here so API errors can be thrown in the executor, while still resulting in a
+	// promise rejection.
+	return new Promise<WidgetLike[]>((resolve) => {
+		// Flat list of all widgets that are being loaded.
+		const loadedWidgets: Promise<WidgetLike>[] = [];
+
+		const widgetProjectors = getCustomElementsByWidgetProjector(root);
+		for (const { children, element: root } of widgetProjectors) {
+			const projector = createProjector({ root });
+			immediatePlaceholderLookup.set(projector, children);
+			projectors.push(projector);
+
+			// Recursion-free, depth first processing of the tree.
+			let processing = [children];
+			while (processing.length > 0) {
+				for (const custom of processing.shift()) {
+					// TODO: This currently assumes `is === 'widget-instance'`
+					const promise = resolveWidgetInstance(registry, custom.element).then((widget) => {
+						// Store the widget for easy access.
+						return custom.widget = widget;
+					});
+					loadedWidgets.push(promise);
+
+					if (custom.children.length > 0) {
+						// Ensure the children are processed.
+						processing.push(custom.children);
+						// Ensure the children are appended to their parent.
+						appendQueue.unshift(custom);
+					}
+				}
+			}
+		}
+
+		// Wait for all widgets to be loaded in parallel.
+		resolve(Promise.all(loadedWidgets));
+	}).then((widgets) => {
+		// Guard against improper widget usage.
+		const uniques = new Set(widgets);
+		if (uniques.size !== widgets.length) {
+			throw new Error('Cannot attach a widget multiple times');
+		}
+		for (const widget of widgets) {
+			// <any> hammer because `widget` could be anything.
+			if ((<any> widget).parent) {
+				throw new Error('Cannot attach a widget that already has a parent');
+			}
+		}
+
+		// Build up the widget hierarchy.
+		for (const custom of appendQueue) {
+			// Assume the widget has the ParentListMixin.
+			const parent = <WidgetLike & ParentListMixin<WidgetLike>> custom.widget;
+			const widgets = custom.children.map(child => child.widget);
+			parent.append(widgets);
+		}
+
+		// Attach all projectors at the same time.
+		const attachedProjectors = projectors.map((projector) => {
+			const immediatePlaceholders = immediatePlaceholderLookup.get(projector);
+			immediatePlaceholderLookup.delete(projector);
+
+			// Append the top-level widgets to the projector.
+			projector.append(immediatePlaceholders.map(custom => custom.widget));
+
+			// Get ready to replace the placeholder elements as soon as the widgets have rendered.
+			const handle = projector.on('attach', () => {
+				handle.destroy();
+
+				const { root } = projector;
+				// Rendered widgets start at this offset.
+				const offset = root.childNodes.length - immediatePlaceholders.length;
+				for (const { element: placeholder } of immediatePlaceholders) {
+					place(root.childNodes[offset], Position.Replace, placeholder);
+				}
+			});
+
+			// Now attach the projector.
+			return projector.attach({ type: 'merge' });
+		});
+
+		// Wait for the projectors to be attached.
+		return Promise.all(attachedProjectors);
+	}).then(() => {
+		return {
+			destroy() {
+				this.destroy = noop;
+				for (const p of projectors) {
+					p.destroy();
+				}
+				// TODO: Instances from the registry should *not* be destroyed when the returned handle is
+				// destroyed, however instances created on the fly from tag registries *should* be.
+			}
+		};
+	});
+};

--- a/src/_resolveListenersMap.ts
+++ b/src/_resolveListenersMap.ts
@@ -1,0 +1,56 @@
+import { EventedListenersMap } from 'dojo-compose/mixins/createEvented';
+import Promise from 'dojo-core/Promise';
+
+import {
+	CombinedRegistry,
+	WidgetListenersMap,
+	WidgetListenerOrArray
+} from './createApp';
+
+function resolveListeners(registry: CombinedRegistry, ref: WidgetListenerOrArray): { value?: any; promise?: Promise<any>; } {
+	if (Array.isArray(ref)) {
+		const resolved = ref.map((item) => {
+			return resolveListeners(registry, item);
+		});
+
+		let isSync = true;
+		const values: any[] = [];
+		for (const result of resolved) {
+			if (result.value) {
+				values.push(result.value);
+			} else {
+				isSync = false;
+				values.push(result.promise);
+			}
+		}
+
+		return isSync ? { value: values } : { promise: Promise.all(values) };
+	}
+
+	if (typeof ref !== 'string') {
+		return { value: ref };
+	}
+
+	return { promise: registry.getAction(<string> ref) };
+}
+
+export default function resolveListenersMap(registry: CombinedRegistry, listeners: WidgetListenersMap): Promise<EventedListenersMap> {
+	if (!listeners) {
+		return null;
+	}
+
+	const map: EventedListenersMap = {};
+	const eventTypes = Object.keys(listeners);
+	return eventTypes.reduce((promise, eventType) => {
+		const resolved = resolveListeners(registry, listeners[eventType]);
+		if (resolved.value) {
+			map[eventType] = resolved.value;
+			return promise;
+		}
+
+		return resolved.promise.then((value) => {
+			map[eventType] = value;
+			return promise;
+		});
+	}, Promise.resolve(map));
+}

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -1,10 +1,12 @@
 import { Action } from 'dojo-actions/createAction';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
+import { Destroyable } from 'dojo-compose/mixins/createDestroyable';
 import { EventedListener } from 'dojo-compose/mixins/createEvented';
 import { ObservableState, State } from 'dojo-compose/mixins/createStateful';
 import { Handle } from 'dojo-core/interfaces';
 import Promise from 'dojo-core/Promise';
 import WeakMap from 'dojo-core/WeakMap';
+import { RenderableMixin } from 'dojo-widgets/mixins/createRenderable';
 
 import IdentityRegistry from './IdentityRegistry';
 import {
@@ -28,9 +30,8 @@ export type StoreLike = ObservableState<State>;
 
 /**
  * Any kind of widget.
- * FIXME: There isn't an official Widget interface. Is this even useful?
  */
-export type WidgetLike = Object;
+export type WidgetLike = Destroyable & RenderableMixin;
 
 /**
  * Factory method to (asynchronously) create an action.

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -295,7 +295,8 @@ export interface AppMixin {
 	/**
 	 * Register a widget factory for a custom element.
 	 *
-	 * The factory will be called each time a widget instance is needed. It'll be called *without* any arguments.
+	 * The factory will be called each time a widget instance is needed. It may be called with an options argument
+	 * derived from a `data-options` attribute on the custom element that is to be be replaced by the created widget.
 	 *
 	 * @param name The name of the custom element. Must be valid according to
 	 *   <https://www.w3.org/TR/custom-elements/#valid-custom-element-name>.

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -16,7 +16,11 @@ import {
 	makeWidgetFactory
 } from './_factories';
 import makeMidResolver, { ToAbsMid, ResolveMid } from './_moduleResolver';
-import realizeCustomElements, { isValidName, normalizeName } from './_realizeCustomElements';
+import realizeCustomElements, {
+	isValidName,
+	normalizeName,
+	RealizationHandle
+} from './_realizeCustomElements';
 
 export { ToAbsMid };
 
@@ -361,7 +365,7 @@ export interface AppMixin {
 	 * @param root The root element that is searched for <widget-instance> elements
 	 * @return A handle to detach rendered widgets from the DOM
 	 */
-	realize(root: Element): Promise<Handle>;
+	realize(root: Element): Promise<RealizationHandle>;
 
 	_registry: CombinedRegistry;
 	_resolveMid: ResolveMid;

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -15,6 +15,7 @@ import {
 	makeWidgetFactory
 } from './_factories';
 import makeMidResolver, { ToAbsMid, ResolveMid } from './_moduleResolver';
+import realizeCustomElements from './_realizeCustomElements';
 
 export { ToAbsMid };
 
@@ -303,6 +304,14 @@ export interface AppMixin {
 	 */
 	loadDefinition(definitions: Definitions): Handle;
 
+	/**
+	 * Take a root element and replace <widget-instance> elements with widget instances.
+	 *
+	 * @param root The root element that is searched for <widget-instance> elements
+	 * @return A handle to detach rendered widgets from the DOM
+	 */
+	realize(root: Element): Promise<Handle>;
+
 	_registry: CombinedRegistry;
 	_resolveMid: ResolveMid;
 }
@@ -453,6 +462,10 @@ const createApp = compose({
 				}
 			}
 		};
+	},
+
+	realize(root: Element) {
+		return realizeCustomElements(this, root);
 	}
 })
 .mixin({

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -56,6 +56,7 @@ export const loaderOptions = {
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
 		{ name: 'dojo-compose', location: 'node_modules/dojo-compose/dist/umd' },
 		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' },
+		{ name: 'dojo-dom', location: 'node_modules/dojo-dom/dist/umd' },
 		{ name: 'dojo-widgets', location: 'node_modules/dojo-widgets/dist/umd' },
 		{ name: 'maquette', location: 'node_modules/maquette/dist' },
 		{ name: 'immutable', location: 'node_modules/immutable/dist' }

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -55,7 +55,10 @@ export const loaderOptions = {
 		{ name: 'tests', location: '_build/tests' },
 		{ name: 'dojo', location: 'node_modules/intern/node_modules/dojo' },
 		{ name: 'dojo-compose', location: 'node_modules/dojo-compose/dist/umd' },
-		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' }
+		{ name: 'dojo-core', location: 'node_modules/dojo-core/dist/umd' },
+		{ name: 'dojo-widgets', location: 'node_modules/dojo-widgets/dist/umd' },
+		{ name: 'maquette', location: 'node_modules/maquette/dist' },
+		{ name: 'immutable', location: 'node_modules/immutable/dist' }
 	]
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 		"./typings/index.d.ts",
 		"./src/_factories.ts",
 		"./src/_moduleResolver.ts",
+		"./src/_realizeCustomElements.ts",
 		"./src/createApp.ts",
 		"./src/IdentityRegistry.ts",
 		"./src/main.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
 		"./src/_factories.ts",
 		"./src/_moduleResolver.ts",
 		"./src/_realizeCustomElements.ts",
+		"./src/_resolveListenersMap.ts",
 		"./src/createApp.ts",
 		"./src/IdentityRegistry.ts",
 		"./src/main.ts",

--- a/typings.json
+++ b/typings.json
@@ -4,6 +4,7 @@
 		"dojo-actions": "npm:dojo-actions",
 		"dojo-compose": "npm:dojo-compose",
 		"dojo-core": "npm:dojo-core",
+		"dojo-dom": "npm:dojo-dom",
 		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-maquette": "github:dojo/typings/custom/dojo2-extras/maquette.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#6008ffd2b3a102d6f07ec5fe7a1a3cd637157757"

--- a/typings.json
+++ b/typings.json
@@ -3,17 +3,29 @@
 	"globalDependencies": {
 		"dojo-actions": "npm:dojo-actions",
 		"dojo-compose": "npm:dojo-compose",
-		"dojo-core": "npm:dojo-core"
+		"dojo-core": "npm:dojo-core",
+		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
+		"extra-maquette": "github:dojo/typings/custom/dojo2-extras/maquette.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
+		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#6008ffd2b3a102d6f07ec5fe7a1a3cd637157757"
+	},
+	"peerDependencies": {
+		"@reactivex/RxJS": "npm:@reactivex/rxjs",
+		"immutable": "npm:immutable",
+		"maquette": "npm:maquette"
 	},
 	"devDependencies": {
 		"chai": "registry:npm/chai#3.5.0+20160415060238",
-		"glob": "registry:npm/glob#6.0.0+20160211003958"
+		"glob": "registry:npm/glob#6.0.0+20160211003958",
+		"immutable": "npm:immutable",
+		"maquette": "npm:maquette"
 	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo-loader": "npm:dojo-loader",
+		"dojo-widgets": "npm:dojo-widgets",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
+		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
 		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",


### PR DESCRIPTION
This adds an `App#realize()` method which can realize the application into one or more projection surfaces.

Currently supports finding and replacing `<attach-widget>` custom elements with registered widgets. Children are appended, though other DOM nodes within `<attach-widget>` are discarded. DOM nodes inside projection surfaces are preserved.

Custom elements can be registered and will be rendered.