### PR TITLE
Default store to provide stateFrom, add data-state-from attribute on custom elements and projectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,9 @@ Widgets can be identified through the `id` property on the options object, a `da
 
 The `data-state-from` attribute may be used on custom elements to specify a store identifier. This will only take effect if a widget ID is also specified. The `stateFrom` property on the options object that is passed to the factory will be set to the referenced store. Any `stateFrom` property in the `data-options` object still takes precedence.
 
-The special `widget-instance` custom element can be used to render a previously registered widget. The `data-widget-id` or `id` attribute is used to retrieve the widget. The `data-state-from` and `data-options` attributes are ignored.
+A default store may be configured by setting the `data-state-from` attribute on the `widget-projector` custom element. It applies to all descendant elements that have IDs, though they can override it by setting their own `data-state-from` attribute or configuring `stateFrom` in their `data-options`.
+
+The special `widget-instance` custom element can be used to render a previously registered widget. The `data-widget-id` or `id` attribute is used to retrieve the widget. The `data-state-from` and `data-options` attributes are ignored. No default store is applied.
 
 A widget ID can only be used once within a realization. Similarly a widget instance can only be rendered once.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ import createApp from 'dojo-app/createApp';
 const app = createApp();
 ```
 
+You can also define a default store at creation time:
+
+```ts
+import createMemoryStore from 'dojo-widgets/util/createMemoryStore';
+
+const defaultStore = createMemoryStore();
+const app = createApp({ defaultStore });
+```
+
+This store will be used as the `stateFrom` option to widget and custom element
+factories, unless another store is specified.
+
 ### Registering actions
 
 If you already have instantiated an action:

--- a/README.md
+++ b/README.md
@@ -101,10 +101,12 @@ app.registerWidget('my-widget', widget);
 You can also register a factory method which creates the widget only when needed:
 
 ```ts
-app.registerWidgetFactory('my-lazy-store', () => {
-	return createWidget();
+app.registerWidgetFactory('my-lazy-widget', (options) => {
+	return createWidget(options);
 });
 ```
+
+The `options` object will have an `id` property set to `my-lazy-widget`.
 
 ### Seeing if an action, store or widget is registered
 

--- a/README.md
+++ b/README.md
@@ -300,11 +300,13 @@ All descending custom elements are replaced by rendered widgets. Widgets for nes
 
 Custom elements are matched (case-insensitively) to registered factories. First the tag name is matched. If no factory is found, and the element has an `is` attribute, that value is used to find a factory. Unrecognized elements are left in the DOM where possible.
 
-A factory option object can be provided in the DOM by setting the `data-options` attribute to a JSON string. The option object may have a `stateFrom` property containing a store identifier. It may also have a `listeners` property containing a widget listener map. Values for each event type can be action identifiers or arrays thereof. These properties are resolved to the actual store and action instances before the factory is called. Additional properties are passed to the factory as-is.
+A factory options object can be provided in the DOM by setting the `data-options` attribute to a JSON string. The options object may have a `stateFrom` property containing a store identifier. It may also have a `listeners` property containing a widget listener map. Values for each event type can be action identifiers or arrays thereof. These properties are resolved to the actual store and action instances before the factory is called. Additional properties are passed to the factory as-is.
 
 Widgets can be identified through the `id` property on the options object, a `data-widget-id` attribute, or an `id` attribute. The options object takes precedence over the `data-widget-id` attribute, which takes precedence over the `id` attribute. It's valid to use the different attributes, but only the most specific ID will be passed to the factory (in the `options` object).
 
-The special `widget-instance` custom element can be used to render a previously registered widget. The `data-widget-id` or `id` attribute is used to retrieve the widget. The `data-options` attribute is ignored.
+The `data-state-from` attribute may be used on custom elements to specify a store identifier. This will only take effect if a widget ID is also specified. The `stateFrom` property on the options object that is passed to the factory will be set to the referenced store. Any `stateFrom` property in the `data-options` object still takes precedence.
+
+The special `widget-instance` custom element can be used to render a previously registered widget. The `data-widget-id` or `id` attribute is used to retrieve the widget. The `data-state-from` and `data-options` attributes are ignored.
 
 A widget ID can only be used once within a realization. Similarly a widget instance can only be rendered once.
 

--- a/src/_realizeCustomElements.ts
+++ b/src/_realizeCustomElements.ts
@@ -249,7 +249,7 @@ function resolveStateFromAttribute(registry: CombinedRegistry, element: Element)
 
 const noop = () => {};
 
-export default function realizeCustomElements(registry: CombinedRegistry, root: Element): Promise<Handle> {
+export default function realizeCustomElements(registry: CombinedRegistry, defaultStore: StoreLike, root: Element): Promise<Handle> {
 	// Bottom up, breadth first queue of custom elements who's children's widgets need to be appended to
 	// their own widget. Combined for all widget projectors.
 	const appendQueue: CustomElement[] = [];
@@ -300,8 +300,9 @@ export default function realizeCustomElements(registry: CombinedRegistry, root: 
 						]).then(([_factory, _options, _store, projectorStore]) => {
 							const factory = <WidgetFactory> _factory;
 							const options = <Options> _options || {};
-							// `data-state-from` store of the element takes precedence, then of the projector.
-							const store = <StoreLike> _store || projectorStore;
+							// `data-state-from` store of the element takes precedence, then of the projector, then
+							// the application's default store.
+							const store = <StoreLike> _store || projectorStore || defaultStore;
 
 							id = options.id;
 							// If the widget has an ID, but stateFrom was not in its `data-options` attribute, and

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -341,7 +341,8 @@ export interface AppMixin {
 	/**
 	 * Register a widget factory with the app.
 	 *
-	 * The factory will be called the first time the widget is needed. It'll be called *without* any arguments.
+	 * The factory will be called the first time the widget is needed. It'll be called with an options object
+	 * that has its `id` property set to the widget ID.
 	 *
 	 * @param id How the widget is identified
 	 * @param factory A factory function that (asynchronously) creates a widget.
@@ -488,7 +489,7 @@ const createApp = compose({
 			const promise = Promise.resolve().then(() => {
 				// Always call the factory in a future turn. This harmonizes behavior regardless of whether the
 				// factory is registered through this method or loaded from a definition.
-				return factory();
+				return factory({ id });
 			});
 			// Replace the registered factory to ensure next time this widget is needed, the same widget is returned.
 			registryHandle.destroy();

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -786,6 +786,20 @@ registerSuite({
 			});
 		},
 
+		'factory is called with an options object that has an ID property'() {
+			let actual: { [p: string]: any } = null;
+			const app = createApp();
+			app.registerWidgetFactory('foo', (options: any) => {
+				actual = options;
+				return createWidget();
+			});
+
+			return app.getWidget('foo').then(() => {
+				assert.isOk(actual);
+				assert.equal(actual['id'], 'foo');
+			});
+		},
+
 		'factory may return a promise': {
 			'should resolve with the widget'() {
 				const expected = createWidget();

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -2726,7 +2726,7 @@ registerSuite({
 							<baz-qux data-options="${opts({ qux: 'quux', thud: 42 })}"></baz-qux>
 						`;
 						return app.realize(root).then(() => {
-							assert.isNotNull(fooBar);
+							assert.isOk(fooBar);
 							assert.equal(fooBar['foo'], 'bar');
 							assert.equal(fooBar['baz'], 5);
 							assert.isOk(bazQux);
@@ -2782,7 +2782,7 @@ registerSuite({
 							app.registerStore('store', expected);
 							projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
 							return app.realize(root).then(() => {
-								assert.isNotNull(actual);
+								assert.isOk(actual);
 								assert.strictEqual(actual.stateFrom, expected);
 							});
 						}

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -79,6 +79,25 @@ function createWidget(): WidgetLike {
 registerSuite({
 	name: 'createApp',
 
+	'#defaultStore': {
+		'defaults to null'() {
+			assert.isNull(createApp().defaultStore);
+		},
+		'set at creation time'() {
+			const store = createStore();
+			const app = createApp({ defaultStore: store });
+			assert.strictEqual(app.defaultStore, store);
+		},
+		'has expected configuration'() {
+			const store = createStore();
+			const app = createApp({ defaultStore: store });
+			const { configurable, enumerable, writable } = Object.getOwnPropertyDescriptor(app, 'defaultStore');
+			assert.isFalse(configurable);
+			assert.isTrue(enumerable);
+			assert.isFalse(writable);
+		}
+	},
+
 	'#getAction': {
 		'no registered action'() {
 			return rejects(createApp().getAction('foo'), Error);
@@ -797,6 +816,21 @@ registerSuite({
 			return app.getWidget('foo').then(() => {
 				assert.isOk(actual);
 				assert.equal(actual['id'], 'foo');
+			});
+		},
+
+		'the stateFrom option is set to the default store, if any'() {
+			let actual: { [p: string]: any } = null;
+			const store = createStore();
+			const app = createApp({ defaultStore: store });
+			app.registerWidgetFactory('foo', (options: any) => {
+				actual = options;
+				return createWidget();
+			});
+
+			return app.getWidget('foo').then(() => {
+				assert.isOk(actual);
+				assert.strictEqual(actual['stateFrom'], store);
 			});
 		},
 
@@ -1975,6 +2009,51 @@ registerSuite({
 					});
 				},
 
+				'the factory\'s stateFrom option is set to the default store, if any'() {
+					let actual: { [p: string]: any } = null;
+					const store = createStore();
+					const app = createApp({ defaultStore: store });
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								factory(options: any) {
+									actual = options;
+									return createWidget();
+								}
+							}
+						]
+					});
+
+					return app.getWidget('foo').then(() => {
+						assert.isOk(actual);
+						assert.strictEqual(actual['stateFrom'], store);
+					});
+				},
+
+				'the definition\'s stateFrom option takes precedence over the default store, if any'() {
+					let actual: { [p: string]: any } = null;
+					const app = createApp({ defaultStore: createStore() });
+					const store = createStore();
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								stateFrom: store,
+								factory(options: any) {
+									actual = options;
+									return createWidget();
+								}
+							}
+						]
+					});
+
+					return app.getWidget('foo').then(() => {
+						assert.isOk(actual);
+						assert.strictEqual(actual['stateFrom'], store);
+					});
+				},
+
 				'factory may return a promise': {
 					'should resolve with the widget'() {
 						const expected = {
@@ -2832,6 +2911,22 @@ registerSuite({
 								assert.isOk(actual);
 								assert.strictEqual(actual.stateFrom, expected);
 							});
+						},
+
+						'takes precedence over the default store'() {
+							const app = createApp({ defaultStore: createStore() });
+							let actual: { stateFrom: StoreLike } = null;
+							app.registerCustomElementFactory('foo-bar', (options) => {
+								actual = <any> options;
+								return createActualWidget({ tagName: 'mark' });
+							});
+							const expected = createStore();
+							app.registerStore('store', expected);
+							projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
+							return app.realize(root).then(() => {
+								assert.isOk(actual);
+								assert.strictEqual(actual.stateFrom, expected);
+							});
 						}
 					},
 
@@ -2964,6 +3059,22 @@ registerSuite({
 					});
 				},
 
+				'takes precedence over the default store'() {
+					let actual: { stateFrom: StoreLike } = null;
+					const app = createApp({ defaultStore: createStore() });
+					app.registerCustomElementFactory('foo-bar', (options) => {
+						actual = <any> options;
+						return createActualWidget({ tagName: 'mark' });
+					});
+					const expected = createStore();
+					app.registerStore('store', expected);
+					projector.innerHTML = `<foo-bar data-state-from="store" id="foo"></foo-bar>`;
+					return app.realize(root).then(() => {
+						assert.isOk(actual);
+						assert.strictEqual(actual.stateFrom, expected);
+					});
+				},
+
 				'is ignored if the element does not have an ID'() {
 					let actual: { stateFrom: StoreLike } = null;
 					app.registerCustomElementFactory('foo-bar', (options) => {
@@ -3017,6 +3128,23 @@ registerSuite({
 					});
 				},
 
+				'takes precedence over the default store'() {
+					let actual: { stateFrom: StoreLike } = null;
+					const app = createApp({ defaultStore: createStore() });
+					app.registerCustomElementFactory('foo-bar', (options) => {
+						actual = <any> options;
+						return createActualWidget({ tagName: 'mark' });
+					});
+					const expected = createStore();
+					app.registerStore('store', expected);
+					projector.setAttribute('data-state-from', 'store');
+					projector.innerHTML = `<foo-bar id="foo"></foo-bar>`;
+					return app.realize(root).then(() => {
+						assert.isOk(actual);
+						assert.strictEqual(actual.stateFrom, expected);
+					});
+				},
+
 				'is ignored for descendant elements that do not have an ID'() {
 					let actual: { stateFrom: StoreLike } = null;
 					app.registerCustomElementFactory('foo-bar', (options) => {
@@ -3029,6 +3157,23 @@ registerSuite({
 					return app.realize(root).then(() => {
 						assert.isOk(actual);
 						assert.notProperty(actual, 'stateFrom');
+					});
+				}
+			},
+
+			'the app has a default store': {
+				'if the element has an ID, causes the custom element factory to be called with a stateFrom option set to the store'() {
+					let actual: { stateFrom: StoreLike } = null;
+					const expected = createStore();
+					const app = createApp({ defaultStore: expected });
+					app.registerCustomElementFactory('foo-bar', (options) => {
+						actual = <any> options;
+						return createActualWidget({ tagName: 'mark' });
+					});
+					projector.innerHTML = `<foo-bar id="foo"></foo-bar>`;
+					return app.realize(root).then(() => {
+						assert.isOk(actual);
+						assert.strictEqual(actual.stateFrom, expected);
 					});
 				}
 			},


### PR DESCRIPTION
Fixes #10 and #12.

Deviated from #12 by making `defaultStore` a creation-time option. It's not possible to change the default store after creation.