### PR TITLE
Immediately configure registered actions

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -393,15 +393,11 @@ const widgets = new WeakMap<App, IdentityRegistry<RegisteredFactory<WidgetLike>>
 
 const createApp = compose({
 	registerAction(id: Identifier, action: ActionLike): Handle {
-		let registryHandle = actions.get(this).register(id, () => {
-			const promise = new Promise<void>((resolve) => {
-				resolve(action.configure(this._registry));
-			}).then(() => action);
-			registryHandle.destroy();
-			registryHandle = actions.get(this).register(id, () => promise);
+		const promise = new Promise<void>((resolve) => {
+			resolve(action.configure(this._registry));
+		}).then(() => action);
 
-			return promise;
-		});
+		const registryHandle = actions.get(this).register(id, () => promise);
 
 		return {
 			destroy() {


### PR DESCRIPTION
Immediately configure the action passed to registerAction(). Any exceptions result in getAction() returning a rejected promise.

Fixes #19.