### PR TITLE
Register default store

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ app.hasWidget('my-widget');
 
 Each method returns `true` if the respective item was registered, and `false` if not.
 
+Besides checking `app.defaultStore` you can use the `DEFAULT_STORE` symbol to see if a default store was provided:
+
+```ts
+import { DEFAULT_STORE } from 'dojo-app/createApp';
+
+app.hasStore(DEFAULT_STORE);
+```
+
 ### Finding the ID under which an action, store or widget was registered
 
 To find the ID under which a particular action, store or widget instance was registered, use the `identify*()` methods:
@@ -150,6 +158,8 @@ app.identifyWidget(widget);
 
 Each method returns the ID string if the respective instance was registered, or throws an error if not.
 
+Note that the default store, if any, is registered under the `DEFAULT_STORE` symbol, *not* an ID string.
+
 ### Loading an action, store or widget
 
 You can load previously registered actions, stores and widgets using the `get*()` methods:
@@ -161,6 +171,14 @@ app.getWidget('my-widget');
 ```
 
 Each method returns a promise for the respective item. If the item was not registered or could not be loaded, the promise is rejected.
+
+Besides accessing `app.defaultStore` you can use the `DEFAULT_STORE` symbol to get the default store:
+
+```ts
+import { DEFAULT_STORE } from 'dojo-app/createApp';
+
+app.getStore(DEFAULT_STORE);
+```
 
 ### Configuring actions
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -431,7 +431,7 @@ export interface AppFactory extends ComposeFactory<App, AppOptions> {}
 
 const noop = () => {};
 
-type RegisteredFactory<T> = () => Promise<T>;
+type RegisteredFactory<T> = () => T | Promise<T>;
 const actionFactories = new WeakMap<App, IdentityRegistry<RegisteredFactory<ActionLike>>>();
 const customElementFactories = new WeakMap<App, IdentityRegistry<WidgetFactory>>();
 const identifiers = new WeakMap<App, Set<Identifier>>();
@@ -569,9 +569,7 @@ const createApp = compose({
 
 		const idHandle = addIdentifier(app, id);
 		const instanceHandle = instanceRegistries.get(app).addStore(store, id);
-
-		const promise = Promise.resolve(store);
-		const registryHandle = storeFactories.get(app).register(id, () => promise);
+		const registryHandle = storeFactories.get(app).register(id, () => store);
 
 		return {
 			destroy() {
@@ -626,9 +624,7 @@ const createApp = compose({
 
 		const idHandle = addIdentifier(app, id);
 		const instanceHandle = instanceRegistries.get(app).addWidget(widget, id);
-
-		const promise = Promise.resolve(widget);
-		const registryHandle = widgetFactories.get(app).register(id, () => promise);
+		const registryHandle = widgetFactories.get(app).register(id, () => widget);
 
 		return {
 			destroy() {

--- a/src/lib/InstanceRegistry.ts
+++ b/src/lib/InstanceRegistry.ts
@@ -17,21 +17,21 @@ const errorStrings: { [type: number]: string } = {
 };
 
 export default class InstanceRegistry {
-	private map = new WeakMap<Instance, { id: Identifier, type: Type }>();
+	private map = new WeakMap<Instance, { id: Identifier | symbol, type: Type }>();
 
 	addAction(action: ActionLike, id: Identifier): Handle {
 		return this.add(action, id, Type.Action);
 	}
 
-	identifyAction(action: ActionLike): string {
+	identifyAction(action: ActionLike): Identifier {
 		return this.identify(action, Type.Action);
 	}
 
-	addStore(store: StoreLike, id: Identifier): Handle {
+	addStore(store: StoreLike, id: Identifier | symbol): Handle {
 		return this.add(store, id, Type.Store);
 	}
 
-	identifyStore(store: StoreLike): string {
+	identifyStore(store: StoreLike): Identifier | symbol {
 		return this.identify(store, Type.Store);
 	}
 
@@ -39,11 +39,14 @@ export default class InstanceRegistry {
 		return this.add(widget, id, Type.Widget);
 	}
 
-	identifyWidget(widget: WidgetLike): string {
+	identifyWidget(widget: WidgetLike): Identifier {
 		return this.identify(widget, Type.Widget);
 	}
 
-	private add(instance: Instance, id: Identifier, type: Type): Handle {
+	private add(instance: ActionLike, id: Identifier, type: Type): Handle;
+	private add(instance: StoreLike, id: Identifier | symbol, type: Type): Handle;
+	private add(instance: WidgetLike, id: Identifier, type: Type): Handle;
+	private add(instance: Instance, id: Identifier | symbol, type: Type): Handle {
 		if (this.map.has(instance)) {
 			const existing = this.map.get(instance);
 			throw new Error(`Could not add ${errorStrings[type]}, already registered as ${errorStrings[existing.type]} with identity ${existing.id}`);
@@ -58,7 +61,10 @@ export default class InstanceRegistry {
 		return handle;
 	}
 
-	private identify(instance: Instance, expectedType: Type): string {
+	private identify(instance: ActionLike, expectedType: Type): string;
+	private identify(instance: StoreLike, expectedType: Type): string | symbol;
+	private identify(instance: WidgetLike, expectedType: Type): string;
+	private identify(instance: Instance, expectedType: Type): string | symbol {
 		if (!this.map.has(instance)) {
 			throw new Error(`Could not identify ${errorStrings[expectedType]}`);
 		}

--- a/src/lib/RegistryProvider.ts
+++ b/src/lib/RegistryProvider.ts
@@ -3,6 +3,7 @@ import Promise from 'dojo-shim/Promise';
 import {
 	ActionLike,
 	CombinedRegistry,
+	Identifier,
 	StoreLike,
 	WidgetLike
 } from '../createApp';
@@ -10,14 +11,14 @@ import {
 /**
  * Registry to (asynchronously) get instances by their ID.
  */
-export interface Registry<T> {
+export interface Registry<I, T> {
 	/**
 	 * Asynchronously get an instance by its ID.
 	 *
 	 * @param id Identifier for the instance that is to be retrieved
 	 * @return A promise for the instance. The promise rejects if no instance was found.
 	 */
-	get(id: string): Promise<T>;
+	get(id: I): Promise<T>;
 
 	/**
 	 * Look up the identifier for which the given value has been registered.
@@ -27,16 +28,16 @@ export interface Registry<T> {
 	 * @param value The value
 	 * @return The identifier
 	 */
-	identify(value: T): string;
+	identify(value: T): I;
 }
 
 /**
  * Provides access to read-only registries for actions, stores and widgets.
  */
 export default class RegistryProvider {
-	private actionRegistry: Registry<ActionLike>;
-	private storeRegistry: Registry<StoreLike>;
-	private widgetRegistry: Registry<WidgetLike>;
+	private actionRegistry: Registry<Identifier, ActionLike>;
+	private storeRegistry: Registry<Identifier | symbol, StoreLike>;
+	private widgetRegistry: Registry<Identifier, WidgetLike>;
 
 	private combinedRegistry: CombinedRegistry;
 	constructor(combinedRegistry: CombinedRegistry) {
@@ -49,11 +50,11 @@ export default class RegistryProvider {
 	 * @param type The type of registry that is required.
 	 * @return The registry.
 	 */
-	get(type: 'actions'): Registry<ActionLike>;
-	get(type: 'stores'): Registry<StoreLike>;
-	get(type: 'widgets'): Registry<WidgetLike>;
-	get(type: string): Registry<any>;
-	get(type: string): Registry<any> {
+	get(type: 'actions'): Registry<Identifier, ActionLike>;
+	get(type: 'stores'): Registry<Identifier | symbol, StoreLike>;
+	get(type: 'widgets'): Registry<Identifier, WidgetLike>;
+	get(type: string): Registry<any, any>;
+	get(type: string): Registry<any, any> {
 		switch (type) {
 			case 'actions':
 				return this.actionRegistry || (this.actionRegistry = {

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -3,7 +3,7 @@ import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import createApp from 'src/createApp';
+import createApp, { DEFAULT_STORE } from 'src/createApp';
 
 import { stub as stubActionFactory } from '../fixtures/action-factory';
 import {
@@ -35,6 +35,15 @@ registerSuite({
 			assert.isFalse(configurable);
 			assert.isTrue(enumerable);
 			assert.isFalse(writable);
+		},
+		'ends up in the registry'() {
+			const store = createStore();
+			const app = createApp({ defaultStore: store });
+			assert.strictEqual(app.identifyStore(store), DEFAULT_STORE);
+			assert.isTrue(app.hasStore(DEFAULT_STORE));
+			return app.getStore(DEFAULT_STORE).then((actual) => {
+				assert.strictEqual(actual, store);
+			});
 		}
 	},
 


### PR DESCRIPTION
A default store can be provided when creating an app. This commit ensures it's added to the registry. Use a symbol (exported as `DEFAULT_STORE`) to register the store, while still requiring new stores
to be registered using string identifiers. This prevents ID collisions.

Update the various registry interfaces to accept symbols when reading stores. The `stateFrom` option still only takes a string, since the default store is already used if `stateFrom` is not provided.

Fixes #27.