### PR TITLE
add() state, define initial state in widget definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,9 +316,11 @@ If you use `factory` in your store definition you can use the `options` property
 
 Like stores, widget factories typically take an options argument. Widget definitions too support the `options` property, letting you specify the object that is passed when the factory is called.
 
-The `options` object must not contain `id`, `listeners` and `stateFrom` properties. These need to be specified in the widget definition itself.
+The `options` object must not contain `id`, `listeners`, `state` and `stateFrom` properties. These need to be specified in the widget definition itself.
 
 Use the `listeners` object to automatically wire events emitted by the widget. Keys are event types. Values are event listeners, actions, string identifiers for actions that are registered with the application factory, or an array containing such values.
+
+Use the `state` property to define an initial state that is added to the widget's store before the widget is created, if any. This will be done lazily once the widget is needed. The store is assumed to reject the initial state if it already contains state for the widget. This error will be ignored and the widget will be created with whatever state was already in the store.
 
 Use the `stateFrom` property to specify the store that the widget should observe for its state. It can be an actual store or a string identifier for a store that is registered with the application factory.
 

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ The `data-state-from` attribute may be used on custom elements to specify a stor
 
 A default widget store may be configured by setting the `data-state-from` attribute on the `app-projector` custom element. It applies to all descendant elements that have IDs, though they can override it by setting their own `data-state-from` attribute or configuring `stateFrom` in their `data-options`.
 
-Custom elements that have widget IDs and a `stateFrom` store may set their `data-state` attribute to an initial state object, encoded as a JSON string. The store will be patched with the initial state and the widget ID before the widget is created.
+Custom elements that have widget IDs and a `stateFrom` store may set their `data-state` attribute to an initial state object, encoded as a JSON string. This initial state will be added to the store before the widget is created. The store is assumed to reject the initial state if it already contains state for the widget. This error will be ignored and the widget will be created with whatever state was already in the store.
 
 The special `app-widget` custom element can be used to render a previously registered widget. The `data-uid` or `id` attribute is used to retrieve the widget. The `data-state`, `data-state-from` and `data-options` attributes are ignored. No default widget store is applied.
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -176,6 +176,11 @@ export interface WidgetDefinition extends ItemDefinition<WidgetFactory, WidgetLi
 	listeners?: WidgetListenersMap;
 
 	/**
+	 * Initial state, to be added to the widget's store, if any.
+	 */
+	state?: any;
+
+	/**
 	 * Identifier of a store which the widget should observe for its state.
 	 *
 	 * When the widget is created, the store is passed as the `stateFrom` option.

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -184,7 +184,8 @@ export interface WidgetDefinition extends ItemDefinition<WidgetFactory, WidgetLi
 	stateFrom?: Identifier | StoreLike;
 
 	/**
-	 * Optional options object passed to the widget factory. Must not contain `id` and `stateFrom` properties.
+	 * Optional options object passed to the widget factory. Must not contain `id`, `listeners` and `stateFrom`
+	 * properties.
 	 */
 	options?: Object;
 }

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -34,7 +34,9 @@ export type ActionLike = Action<any, any, any>;
 /**
  * Any kind of store.
  */
-export type StoreLike = ObservableState<State>;
+export type StoreLike = ObservableState<State> & {
+	add<T>(item: T, options?: any): Promise<T>;
+}
 
 /**
  * Any kind of widget.

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -171,6 +171,9 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 		if ('listeners' in definition) {
 			throw new TypeError('Cannot specify listeners option when widget definition points directly at an instance');
 		}
+		if ('state' in definition) {
+			throw new TypeError('Cannot specify state option when widget definition points directly at an instance');
+		}
 		if ('stateFrom' in definition) {
 			throw new TypeError('Cannot specify stateFrom option when widget definition points directly at an instance');
 		}
@@ -200,8 +203,9 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 			listeners?: EventedListenersMap;
 		}
 
+		const { id, state: initialState } = definition;
 		const options: Options = assign({
-			id: definition.id,
+			id,
 			registryProvider
 		}, rawOptions);
 
@@ -219,6 +223,13 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 			}
 			if (store) {
 				options.stateFrom = store;
+			}
+
+			if (store && initialState) {
+				return store.add(initialState, { id })
+					// Ignore error, assume store already contains state for this widget.
+					.catch(() => undefined)
+					.then(() => factory(options));
 			}
 
 			return factory(options);

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -1,5 +1,5 @@
-import { from as arrayFrom } from 'dojo-shim/array';
 import { Handle } from 'dojo-core/interfaces';
+import { from as arrayFrom } from 'dojo-shim/array';
 import Promise from 'dojo-shim/Promise';
 import Set from 'dojo-shim/Set';
 import Map from 'dojo-shim/Map';

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -362,9 +362,10 @@ export default function realizeCustomElements(
 							if (id && options.stateFrom) {
 								const initialState = getInitialState(custom.element);
 								if (initialState) {
-									return options.stateFrom.patch(initialState, { id }).then(() => {
-										return factory(options);
-									});
+									return options.stateFrom.add(initialState, { id })
+										// Ignore error, assume store already contains state for this widget.
+										.catch(() => undefined)
+										.then(() => factory(options));
 								}
 							}
 


### PR DESCRIPTION
Use `add()` rather than `patch()` to add state to the store. Unlike `patch()`, `add()` won't replace existing data. This allows initial state to be provided, while applications can still restore previously persisted state and have that state be used when widgets are rendered.

Rejections from `add()` are ignored. It is assumed these arise when data already exists in the store.

Widget definitions can now declare initial state, creating parity with the declarative `data-state` attribute.