### PR TITLE
Support children in widget definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ Like stores, widget factories typically take an options argument. Widget definit
 
 The `options` object must not contain `id`, `listeners`, `state` and `stateFrom` properties. These need to be specified in the widget definition itself.
 
+Use the `children` property to define nested widgets that are lazily loaded when their parent widget is needed. Values may be arrays or objects. The array may contain widget IDs or nested definitions. Similarly the object values may be widget IDs or nested definitions. Widgets from nested definitions are available across the app. It is assumed the parent widget can handle the array or object `children` option.
+
 Use the `listeners` object to automatically wire events emitted by the widget. Keys are event types. Values are event listeners, actions, string identifiers for actions that are registered with the application factory, or an array containing such values.
 
 Use the `state` property to define an initial state that is added to the widget's store before the widget is created, if any. This will be done lazily once the widget is needed. The store is assumed to reject the initial state if it already contains state for the widget. This error will be ignored and the widget will be created with whatever state was already in the store.

--- a/src/lib/extractRegistrationElements.ts
+++ b/src/lib/extractRegistrationElements.ts
@@ -427,17 +427,19 @@ function createWidgetDefinition(
 		stateFrom
 	}: WidgetTask
 ): WidgetDefinition {
+	const factory: WidgetFactory = (options) => {
+		if (isFactoryResolver(resolver)) {
+			return resolveMid<WidgetFactory>(resolver.factory)
+				.then((factory) => factory(options));
+		}
+		else {
+			return resolveMid<WidgetLike>(resolver.from, resolver.importName || 'default');
+		}
+	};
+
 	return {
 		id,
-		factory(options) {
-			if (isFactoryResolver(resolver)) {
-				return resolveMid<WidgetFactory>(resolver.factory)
-					.then((factory) => factory(options));
-			}
-			else {
-				return resolveMid<WidgetLike>(resolver.from, resolver.importName || 'default');
-			}
-		},
+		factory,
 		listeners,
 		options,
 		state,

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -133,8 +133,8 @@ export function makeActionFactory(definition: ActionDefinition, resolveMid: Reso
 			resolveFactory('action', definition, resolveMid),
 			resolveStore(registry, definition)
 		]).then(([_factory, _store]) => {
-			const factory = <ActionFactory> _factory;
-			const store = <StoreLike> _store || defaultActionStore;
+			const factory: ActionFactory = _factory;
+			const store: StoreLike = _store || defaultActionStore;
 
 			const options = { registryProvider, stateFrom: store };
 
@@ -230,9 +230,9 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 			resolveListenersMap(registry, definition.listeners),
 			resolveStore(registry, definition)
 		]).then(([_factory, _listeners, _store]) => {
-			const factory = <WidgetFactory> _factory;
-			const listeners = <EventedListenersMap> _listeners;
-			const store = <StoreLike> _store || defaultWidgetStore;
+			const factory: WidgetFactory = _factory;
+			const listeners: EventedListenersMap = _listeners;
+			const store: StoreLike = _store || defaultWidgetStore;
 
 			if (listeners) {
 				options.listeners = listeners;

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -1,4 +1,5 @@
 import { EventedListenersMap } from 'dojo-compose/mixins/createEvented';
+import { Hash } from 'dojo-core/interfaces';
 import { assign } from 'dojo-core/lang';
 import Promise from 'dojo-shim/Promise';
 
@@ -7,6 +8,7 @@ import {
 	ActionFactory,
 	ActionLike,
 	CustomElementDefinition,
+	Identifier,
 	ItemDefinition,
 	ReadOnlyRegistry,
 	StoreDefinition,
@@ -31,6 +33,26 @@ function resolveStore(registry: ReadOnlyRegistry, definition: ActionDefinition |
 	}
 
 	return registry.getStore(<string> stateFrom);
+}
+
+type WidgetChildren = WidgetLike[] | Hash<WidgetLike>;
+
+function resolveChildren(registry: ReadOnlyRegistry, children: Identifier[] | Hash<Identifier>): Promise<WidgetChildren> {
+	if (Array.isArray(children)) {
+		const widgetPromises = children.map((id) => registry.getWidget(id));
+		return Promise.all(widgetPromises);
+	}
+	else {
+		const keys = Object.keys(children);
+		const widgetPromises = keys.map((key) => registry.getWidget(children[key]));
+		return Promise.all(widgetPromises)
+			.then((widgets) => {
+				return keys.reduce<Hash<WidgetLike>>((acc, key, index) => {
+					acc[key] = widgets[index];
+					return acc;
+				}, {});
+			});
+	}
 }
 
 type Factory = ActionFactory | StoreFactory | WidgetFactory;
@@ -189,11 +211,19 @@ export function makeStoreFactory(definition: StoreDefinition, resolveMid: Resolv
 	};
 }
 
-export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: ResolveMid, registry: ReadOnlyRegistry): WidgetFactory {
+export function makeWidgetFactory(
+	definition: WidgetDefinition,
+	resolveMid: ResolveMid,
+	registry: ReadOnlyRegistry,
+	children?: Identifier[] | Hash<Identifier>
+): WidgetFactory {
 	if (!('factory' in definition || 'instance' in definition)) {
 		throw new TypeError('Widget definitions must specify either the factory or instance option');
 	}
 	if ('instance' in definition) {
+		if ('children' in definition) {
+			throw new TypeError('Cannot specify children option when widget definition points directly at an instance');
+		}
 		if ('listeners' in definition) {
 			throw new TypeError('Cannot specify listeners option when widget definition points directly at an instance');
 		}
@@ -210,8 +240,8 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 
 	const { options: rawOptions } = definition;
 	if (rawOptions) {
-		if ('id' in rawOptions || 'listeners' in rawOptions || 'stateFrom' in rawOptions) {
-			throw new TypeError('id, listeners and stateFrom options should be in the widget definition itself, not its options value');
+		if ('children' in rawOptions || 'id' in rawOptions || 'listeners' in rawOptions || 'stateFrom' in rawOptions) {
+			throw new TypeError('children, id, listeners and stateFrom options should be in the widget definition itself, not its options value');
 		}
 		if ('registryProvider' in rawOptions) {
 			throw new TypeError('registryProvider option must not be specified');
@@ -226,14 +256,21 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 		}, rawOptions);
 
 		return Promise.all<any>([
+			children ? resolveChildren(registry, children) : null,
 			resolveFactory('widget', definition, resolveMid),
 			resolveListenersMap(registry, definition.listeners),
 			resolveStore(registry, definition)
-		]).then(([_factory, _listeners, _store]) => {
+		]).then(([_children, _factory, _listeners, _store]) => {
+			const children: WidgetChildren = _children;
 			const factory: WidgetFactory = _factory;
 			const listeners: EventedListenersMap = _listeners;
 			const store: StoreLike = _store || defaultWidgetStore;
 
+			if (children) {
+				// Assigning children to non-container widget factory options should be harmless, and the factory is
+				// typed such that it doesn't accept children options anyway. Use the <any> hammer to make life easier.
+				(<any> options).children = children;
+			}
 			if (listeners) {
 				options.listeners = listeners;
 			}


### PR DESCRIPTION
Children can now be defined in widget definitions. Both arrays and object forms are supported. Nested definitions are loaded and made available across the app (they're not scoped to their parent). IDs may
also be provided.

Child widgets are resolved before their parent is created. They're passed to the parent through the children option.

Related to #30, though this does not provide an automatic way of rendering the root widgets.

See example in https://github.com/dojo/examples/pull/91.
