### PR TITLE
Require IDs to be unique across the app

### DIFF
--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -282,6 +282,7 @@ const noop = () => {};
  */
 export default function realizeCustomElements(
 	defaultStore: StoreLike,
+	addIdentifier: (id: string) => Handle,
 	registerInstance: (widget: WidgetLike, id: string) => Handle,
 	registry: CombinedRegistry,
 	registryProvider: RegistryProvider,
@@ -371,15 +372,18 @@ export default function realizeCustomElements(
 						if (!isWidgetInstance) {
 							managedWidgets.push(widget);
 
-							// Belatedly ensure no other widget with this ID exists.
-							if (id && registry.hasWidget(id)) {
-								throw new Error(`A widget with ID '${id}' already exists`);
+							// Assign a presumably unique ID if necessary. It's OK for the widget to not be aware of its
+							// generated ID.
+							if (!id) {
+								id = generateId();
 							}
 
-							// Add the instance to the various registries the app may maintain. This requires an ID, so
-							// generate one if necessary. It's OK for the widget to not be aware of its generated ID.
+							// Belatedly ensure no other widget with this ID exists.
+							handles.push(addIdentifier(id));
+
+							// Add the instance to the various registries the app may maintain.
 							try {
-								handles.push(registerInstance(widget, id || generateId()));
+								handles.push(registerInstance(widget, id));
 							} catch (_) {
 								// registerInstance() will throw if the widget has already been registered. Throw a
 								// friendlier error message.

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -52,13 +52,13 @@ registerSuite({
 					],
 					stores: [
 						{
-							id: 'foo',
+							id: 'bar',
 							factory: createStore
 						}
 					],
 					widgets: [
 						{
-							id: 'foo',
+							id: 'baz',
 							factory: createWidget
 						}
 					]
@@ -67,8 +67,8 @@ registerSuite({
 				handle.destroy();
 				assert.isTrue(app.hasAction('remains'));
 				assert.isFalse(app.hasAction('foo'));
-				assert.isFalse(app.hasStore('foo'));
-				assert.isFalse(app.hasWidget('foo'));
+				assert.isFalse(app.hasStore('bar'));
+				assert.isFalse(app.hasWidget('baz'));
 			}
 		},
 
@@ -119,69 +119,28 @@ registerSuite({
 		const app = createApp({ toAbsMid });
 
 		app.registerAction('action', createAction());
-		assert.throws(() => {
-			app.registerAction('action', createAction());
-		}, Error);
-		assert.throws(() => {
-			app.registerActionFactory('action', createAction);
-		}, Error);
-		assert.throws(() => {
-			app.loadDefinition({
-				actions: [
-					{
-						id: 'action',
-						factory: createAction
-					}
-				]
-			});
-		}, Error);
-		assert.doesNotThrow(() => {
-			app.registerStore('action', createStore());
-			app.registerWidget('action', createWidget());
-		});
-
 		app.registerStore('store', createStore());
-		assert.throws(() => {
-			app.registerStore('store', createStore());
-		}, Error);
-		assert.throws(() => {
-			app.registerStoreFactory('store', createStore);
-		}, Error);
-		assert.throws(() => {
-			app.loadDefinition({
-				stores: [
-					{
-						id: 'store',
-						factory: createStore
-					}
-				]
-			});
-		}, Error);
-		assert.doesNotThrow(() => {
-			app.registerAction('store', createAction());
-			app.registerWidget('store', createWidget());
-		});
-
 		app.registerWidget('widget', createWidget());
-		assert.throws(() => {
-			app.registerWidget('widget', createWidget());
-		}, Error);
-		assert.throws(() => {
-			app.registerWidgetFactory('widget', createWidget);
-		}, Error);
-		assert.throws(() => {
-			app.loadDefinition({
-				widgets: [
-					{
-						id: 'widget',
-						factory: createWidget
-					}
-				]
-			});
-		}, Error);
-		assert.doesNotThrow(() => {
-			app.registerAction('widget', createAction());
-			app.registerStore('widget', createStore());
+
+		[
+			(id: string) => app.registerAction(id, createAction()),
+			(id: string) => app.registerActionFactory(id, createAction),
+			(id: string) => {
+				app.loadDefinition({
+					actions: [
+						{
+							id: id,
+							factory: createAction
+						}
+					]
+				});
+			},
+			(id: string) => app.registerStore(id, createStore()),
+			(id: string) => app.registerWidget(id, createWidget())
+		].forEach((fn) => {
+			for (const id of ['action', 'store', 'widget']) {
+				assert.throws(() => fn(id), Error);
+			}
 		});
 	},
 
@@ -236,7 +195,7 @@ registerSuite({
 		const handles: Handle[] = [];
 		handles.push(
 			app.registerActionFactory('foo', () => action),
-			app.registerStoreFactory('foo', () => <any> action)
+			app.registerStoreFactory('bar', () => <any> action)
 		);
 
 		rejects(

--- a/tests/unit/createApp/realize.ts
+++ b/tests/unit/createApp/realize.ts
@@ -864,22 +864,13 @@ registerSuite({
 			});
 		},
 
-		'IDs must be unique within the realization'() {
-			app.registerCustomElementFactory('foo-bar', () => createActualWidget());
-			projector.innerHTML = `
-				<foo-bar id="unique"></foo-bar>
-				<foo-bar id="unique"></foo-bar>
-			`;
-			return rejects(app.realize(root), Error, 'A widget with ID \'unique\' already exists');
-		},
-
 		'IDs must be unique within the application'() {
 			app.registerCustomElementFactory('foo-bar', () => createActualWidget());
-			app.registerWidget('unique', createWidget());
+			app.registerAction('unique', createAction());
 			projector.innerHTML = `
 				<foo-bar id="unique"></foo-bar>
 			`;
-			return rejects(app.realize(root), Error, 'A widget with ID \'unique\' already exists');
+			return rejects(app.realize(root), Error, '\'unique\' has already been used as an identifier');
 		},
 
 		'widgets without IDs can still be identified'() {

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -733,7 +733,7 @@ registerSuite({
 					app.loadDefinition({
 						widgets: [
 							{
-								id: 'foo',
+								id: 'baz',
 								factory(options: any) {
 									actual = options.listeners;
 									return createWidget();
@@ -746,7 +746,7 @@ registerSuite({
 						]
 					});
 
-					return app.getWidget('foo').then(() => {
+					return app.getWidget('baz').then(() => {
 						assert.strictEqual(actual['foo'], expected.foo);
 						assert.strictEqual(actual['bar'], expected.bar);
 					});
@@ -764,7 +764,7 @@ registerSuite({
 					app.loadDefinition({
 						widgets: [
 							{
-								id: 'foo',
+								id: 'bar',
 								factory(options: any) {
 									actual = options.listeners;
 									return createWidget();
@@ -777,7 +777,7 @@ registerSuite({
 						]
 					});
 
-					return app.getWidget('foo').then(() => {
+					return app.getWidget('bar').then(() => {
 						assert.strictEqual(actual['foo'], expected.foo);
 						assert.strictEqual(actual['bar'], expected.bar);
 					});
@@ -792,7 +792,7 @@ registerSuite({
 					app.loadDefinition({
 						widgets: [
 							{
-								id: 'foo',
+								id: 'bar',
 								factory(options: any) {
 									actual = options.listeners;
 									return createWidget();
@@ -805,7 +805,7 @@ registerSuite({
 						]
 					});
 
-					return app.getWidget('foo').then(() => {
+					return app.getWidget('bar').then(() => {
 						const foo = <EventedListener<any>[]> actual['foo'];
 						assert.strictEqual(foo[0], expected[0]);
 						assert.strictEqual(foo[1], expected[1]);


### PR DESCRIPTION
As a precaution, require all IDs to be unique for the app, which helps if action and widget are created from the same store. This then carries over into `id` attributes in the DOM, so that's good too.