### PR TITLE
Default stores by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,22 @@ import createApp from 'dojo-app/createApp';
 const app = createApp();
 ```
 
-You can also define a default store at creation time:
+You can also define a default widget store at creation time:
 
 ```ts
 import createMemoryStore from 'dojo-widgets/util/createMemoryStore';
 
-const defaultStore = createMemoryStore();
-const app = createApp({ defaultStore });
+const defaultWidgetStore = createMemoryStore();
+const app = createApp({ defaultWidgetStore });
 ```
 
-Or you can, *just once*, assign a default store:
+Or you can, *just once*, assign a default widget store:
 
 ```ts
 import createMemoryStore from 'dojo-widgets/util/createMemoryStore';
 
 const app = createApp();
-app.defaultStore = createMemoryStore();
+app.defaultWidgetStore = createMemoryStore();
 ```
 
 This store will be used as the `stateFrom` option to widget and custom element factories, unless another store is specified.
@@ -146,12 +146,12 @@ app.hasWidget('my-widget');
 
 Each method returns `true` if the respective item was registered, and `false` if not.
 
-Besides checking `app.defaultStore` you can use the `DEFAULT_STORE` symbol to see if a default store was provided:
+Besides checking `app.defaultWidgetStore` you can use the `DEFAULT_WIDGET_STORE` symbol to see if a default widget store was provided:
 
 ```ts
-import { DEFAULT_STORE } from 'dojo-app/createApp';
+import { DEFAULT_WIDGET_STORE } from 'dojo-app/createApp';
 
-app.hasStore(DEFAULT_STORE);
+app.hasStore(DEFAULT_WIDGET_STORE);
 ```
 
 ### Finding the ID under which an action, store or widget was registered
@@ -166,7 +166,7 @@ app.identifyWidget(widget);
 
 Each method returns the ID string if the respective instance was registered, or throws an error if not.
 
-Note that the default store, if any, is registered under the `DEFAULT_STORE` symbol, *not* an ID string.
+Note that the default widget store, if any, is registered under the `DEFAULT_WIDGET_STORE` symbol, *not* an ID string.
 
 ### Loading an action, store or widget
 
@@ -180,12 +180,12 @@ app.getWidget('my-widget');
 
 Each method returns a promise for the respective item. If the item was not registered or could not be loaded, the promise is rejected.
 
-Besides accessing `app.defaultStore` you can use the `DEFAULT_STORE` symbol to get the default store:
+Besides accessing `app.defaultWidgetStore` you can use the `DEFAULT_WIDGET_STORE` symbol to get the default widget store:
 
 ```ts
-import { DEFAULT_STORE } from 'dojo-app/createApp';
+import { DEFAULT_WIDGET_STORE } from 'dojo-app/createApp';
 
-app.getStore(DEFAULT_STORE);
+app.getStore(DEFAULT_WIDGET_STORE);
 ```
 
 ### Configuring actions
@@ -374,11 +374,11 @@ Widgets can be identified through the `id` property on the options object, a `da
 
 The `data-state-from` attribute may be used on custom elements to specify a store identifier. This will only take effect if a widget ID is also specified. The `stateFrom` property on the options object that is passed to the factory will be set to the referenced store. Any `stateFrom` property in the `data-options` object still takes precedence.
 
-A default store may be configured by setting the `data-state-from` attribute on the `app-projector` custom element. It applies to all descendant elements that have IDs, though they can override it by setting their own `data-state-from` attribute or configuring `stateFrom` in their `data-options`.
+A default widget store may be configured by setting the `data-state-from` attribute on the `app-projector` custom element. It applies to all descendant elements that have IDs, though they can override it by setting their own `data-state-from` attribute or configuring `stateFrom` in their `data-options`.
 
 Custom elements that have widget IDs and a `stateFrom` store may set their `data-state` attribute to an initial state object, encoded as a JSON string. The store will be patched with the initial state and the widget ID before the widget is created.
 
-The special `app-widget` custom element can be used to render a previously registered widget. The `data-uid` or `id` attribute is used to retrieve the widget. The `data-state`, `data-state-from` and `data-options` attributes are ignored. No default store is applied.
+The special `app-widget` custom element can be used to render a previously registered widget. The `data-uid` or `id` attribute is used to retrieve the widget. The `data-state`, `data-state-from` and `data-options` attributes are ignored. No default widget store is applied.
 
 A widget ID can only be used once within an application. Similarly a widget instance can only be rendered once. The `getWidget()`, `hasWidget()` and `identifyWidget()` methods will work with widgets created by custom element factories.
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,16 @@ const defaultStore = createMemoryStore();
 const app = createApp({ defaultStore });
 ```
 
-This store will be used as the `stateFrom` option to widget and custom element
-factories, unless another store is specified.
+Or you can, *just once*, assign a default store:
+
+```ts
+import createMemoryStore from 'dojo-widgets/util/createMemoryStore';
+
+const app = createApp();
+app.defaultStore = createMemoryStore();
+```
+
+This store will be used as the `stateFrom` option to widget and custom element factories, unless another store is specified.
 
 ### Registering actions
 

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -203,7 +203,7 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 		stateFrom?: StoreLike;
 	}
 
-	return ({ registryProvider, stateFrom: defaultStore }: BaseOptions) => {
+	return ({ registryProvider, stateFrom: defaultWidgetStore }: BaseOptions) => {
 		interface Options extends BaseOptions {
 			id: string;
 			listeners?: EventedListenersMap;
@@ -221,7 +221,7 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 		]).then(([_factory, _listeners, _store]) => {
 			const factory = <WidgetFactory> _factory;
 			const listeners = <EventedListenersMap> _listeners;
-			const store = <StoreLike> _store || defaultStore;
+			const store = <StoreLike> _store || defaultWidgetStore;
 
 			if (listeners) {
 				options.listeners = listeners;

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -272,7 +272,7 @@ const noop = () => {};
 /**
  * Realizes custom elements within a root element.
  *
- * @param defaultStore The default store of the app, may be null.
+ * @param defaultWidgetStore The default widget store of the app, may be null.
  * @param registerInstance Callback for registering new widget instances with the app
  * @param registry Read-only registry of actions, custom element factories, stores and widgets
  * @param registryProvider Registry provider, to be passed to custom element factories
@@ -281,7 +281,7 @@ const noop = () => {};
  * @return A handle to detach rendered widgets from the DOM and remove them from the widget registry
  */
 export default function realizeCustomElements(
-	defaultStore: StoreLike,
+	defaultWidgetStore: StoreLike,
 	addIdentifier: (id: string) => Handle,
 	registerInstance: (widget: WidgetLike, id: string) => Handle,
 	registry: CombinedRegistry,
@@ -339,13 +339,13 @@ export default function realizeCustomElements(
 							const factory = <WidgetFactory> _factory;
 							const options = <Options> _options;
 							// `data-state-from` store of the element takes precedence, then of the projector, then
-							// the application's default store.
-							const store = <StoreLike> _store || projectorStore || defaultStore;
+							// the application's default widget store.
+							const store = <StoreLike> _store || projectorStore || defaultWidgetStore;
 
 							id = options.id;
 							// If the widget has an ID, but stateFrom was not in its `data-options` attribute, and
 							// either its `data-state-from` attribute resolved to a store, or there is a default
-							// store, set the stateFrom option to the `data-state-from` or default store.
+							// store, set the stateFrom option to the `data-state-from` or default widget store.
 							if (id && !options.stateFrom && store) {
 								options.stateFrom = store;
 							}

--- a/tests/fixtures/action-factory.ts
+++ b/tests/fixtures/action-factory.ts
@@ -7,5 +7,5 @@ export function stub (stub: ActionFactory) {
 }
 
 export default function (registry: CombinedRegistry) {
-	return factory(registry);
+	return factory(registry, null);
 }

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -3,7 +3,7 @@ import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import createApp, { DEFAULT_STORE } from 'src/createApp';
+import createApp, { DEFAULT_WIDGET_STORE } from 'src/createApp';
 
 import { stub as stubActionFactory } from '../fixtures/action-factory';
 import {
@@ -19,33 +19,33 @@ const { toAbsMid } = require;
 registerSuite({
 	name: 'createApp',
 
-	'#defaultStore': {
+	'#defaultWidgetStore': {
 		'defaults to null'() {
-			assert.isNull(createApp().defaultStore);
+			assert.isNull(createApp().defaultWidgetStore);
 		},
 		'can be set at creation time'() {
 			const store = createStore();
-			const app = createApp({ defaultStore: store });
-			assert.strictEqual(app.defaultStore, store);
+			const app = createApp({ defaultWidgetStore: store });
+			assert.strictEqual(app.defaultWidgetStore, store);
 		},
 		'can be set after creation'() {
 			const store = createStore();
 			const app = createApp();
-			app.defaultStore = store;
-			assert.strictEqual(app.defaultStore, store);
+			app.defaultWidgetStore = store;
+			assert.strictEqual(app.defaultWidgetStore, store);
 		},
 		'can only be set once'() {
 			const store = createStore();
-			const app = createApp({ defaultStore: store });
-			assert.throws(() => app.defaultStore = createStore(), Error);
-			assert.strictEqual(app.defaultStore, store);
+			const app = createApp({ defaultWidgetStore: store });
+			assert.throws(() => app.defaultWidgetStore = createStore(), Error);
+			assert.strictEqual(app.defaultWidgetStore, store);
 		},
 		'ends up in the registry'() {
 			const store = createStore();
-			const app = createApp({ defaultStore: store });
-			assert.strictEqual(app.identifyStore(store), DEFAULT_STORE);
-			assert.isTrue(app.hasStore(DEFAULT_STORE));
-			return app.getStore(DEFAULT_STORE).then((actual) => {
+			const app = createApp({ defaultWidgetStore: store });
+			assert.strictEqual(app.identifyStore(store), DEFAULT_WIDGET_STORE);
+			assert.isTrue(app.hasStore(DEFAULT_WIDGET_STORE));
+			return app.getStore(DEFAULT_WIDGET_STORE).then((actual) => {
 				assert.strictEqual(actual, store);
 			});
 		}

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -23,18 +23,22 @@ registerSuite({
 		'defaults to null'() {
 			assert.isNull(createApp().defaultStore);
 		},
-		'set at creation time'() {
+		'can be set at creation time'() {
 			const store = createStore();
 			const app = createApp({ defaultStore: store });
 			assert.strictEqual(app.defaultStore, store);
 		},
-		'has expected configuration'() {
+		'can be set after creation'() {
+			const store = createStore();
+			const app = createApp();
+			app.defaultStore = store;
+			assert.strictEqual(app.defaultStore, store);
+		},
+		'can only be set once'() {
 			const store = createStore();
 			const app = createApp({ defaultStore: store });
-			const { configurable, enumerable, writable } = Object.getOwnPropertyDescriptor(app, 'defaultStore');
-			assert.isFalse(configurable);
-			assert.isTrue(enumerable);
-			assert.isFalse(writable);
+			assert.throws(() => app.defaultStore = createStore(), Error);
+			assert.strictEqual(app.defaultStore, store);
 		},
 		'ends up in the registry'() {
 			const store = createStore();
@@ -186,11 +190,10 @@ registerSuite({
 				assert.throws(() => registryProvider.get('foo'), Error, 'No such store: foo');
 			},
 
-			'has expected configuration'() {
-				const { configurable, enumerable, writable } = Object.getOwnPropertyDescriptor(app, 'registryProvider');
-				assert.isFalse(configurable);
-				assert.isTrue(enumerable);
-				assert.isFalse(writable);
+			'is read-only'() {
+				assert.throws(() => {
+					app.registryProvider = null;
+				}, TypeError);
 			}
 		};
 	})(),

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -3,7 +3,7 @@ import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import createApp, { DEFAULT_WIDGET_STORE } from 'src/createApp';
+import createApp, { DEFAULT_ACTION_STORE, DEFAULT_WIDGET_STORE } from 'src/createApp';
 
 import { stub as stubActionFactory } from '../fixtures/action-factory';
 import {
@@ -18,6 +18,38 @@ const { toAbsMid } = require;
 
 registerSuite({
 	name: 'createApp',
+
+	'#defaultActionStore': {
+		'defaults to null'() {
+			assert.isNull(createApp().defaultActionStore);
+		},
+		'can be set at creation time'() {
+			const store = createStore();
+			const app = createApp({ defaultActionStore: store });
+			assert.strictEqual(app.defaultActionStore, store);
+		},
+		'can be set after creation'() {
+			const store = createStore();
+			const app = createApp();
+			app.defaultActionStore = store;
+			assert.strictEqual(app.defaultActionStore, store);
+		},
+		'can only be set once'() {
+			const store = createStore();
+			const app = createApp({ defaultActionStore: store });
+			assert.throws(() => app.defaultActionStore = createStore(), Error);
+			assert.strictEqual(app.defaultActionStore, store);
+		},
+		'ends up in the registry'() {
+			const store = createStore();
+			const app = createApp({ defaultActionStore: store });
+			assert.strictEqual(app.identifyStore(store), DEFAULT_ACTION_STORE);
+			assert.isTrue(app.hasStore(DEFAULT_ACTION_STORE));
+			return app.getStore(DEFAULT_ACTION_STORE).then((actual) => {
+				assert.strictEqual(actual, store);
+			});
+		}
+	},
 
 	'#defaultWidgetStore': {
 		'defaults to null'() {

--- a/tests/unit/createApp/realize.ts
+++ b/tests/unit/createApp/realize.ts
@@ -428,8 +428,8 @@ registerSuite({
 				});
 			},
 
-			'takes precedence over the default store'() {
-				const app = createApp({ defaultStore: createStore() });
+			'takes precedence over the default widget store'() {
+				const app = createApp({ defaultWidgetStore: createStore() });
 				let actual: { stateFrom: StoreLike } = null;
 				app.registerCustomElementFactory('foo-bar', (options) => {
 					actual = <any> options;
@@ -573,9 +573,9 @@ registerSuite({
 			});
 		},
 
-		'takes precedence over the default store'() {
+		'takes precedence over the default widget store'() {
 			let actual: { stateFrom: StoreLike } = null;
-			const app = createApp({ defaultStore: createStore() });
+			const app = createApp({ defaultWidgetStore: createStore() });
 			app.registerCustomElementFactory('foo-bar', (options) => {
 				actual = <any> options;
 				return createActualWidget({ tagName: 'mark' });
@@ -642,9 +642,9 @@ registerSuite({
 			});
 		},
 
-		'takes precedence over the default store'() {
+		'takes precedence over the default widget store'() {
 			let actual: { stateFrom: StoreLike } = null;
-			const app = createApp({ defaultStore: createStore() });
+			const app = createApp({ defaultWidgetStore: createStore() });
 			app.registerCustomElementFactory('foo-bar', (options) => {
 				actual = <any> options;
 				return createActualWidget({ tagName: 'mark' });
@@ -675,11 +675,11 @@ registerSuite({
 		}
 	},
 
-	'the app has a default store': {
+	'the app has a default widget store': {
 		'if the element has an ID, causes the custom element factory to be called with a stateFrom option set to the store'() {
 			let actual: { stateFrom: StoreLike } = null;
 			const expected = createStore();
-			const app = createApp({ defaultStore: expected });
+			const app = createApp({ defaultWidgetStore: expected });
 			app.registerCustomElementFactory('foo-bar', (options) => {
 				actual = <any> options;
 				return createActualWidget({ tagName: 'mark' });

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -193,10 +193,10 @@ registerSuite({
 			});
 		},
 
-		'the stateFrom option is set to the default store, if any'() {
+		'the stateFrom option is set to the default widget store, if any'() {
 			let actual: { [p: string]: any } = null;
 			const store = createStore();
-			const app = createApp({ defaultStore: store });
+			const app = createApp({ defaultWidgetStore: store });
 			app.registerWidgetFactory('foo', (options: any) => {
 				actual = options;
 				return createWidget();
@@ -527,10 +527,10 @@ registerSuite({
 				});
 			},
 
-			'the factory\'s stateFrom option is set to the default store, if any'() {
+			'the factory\'s stateFrom option is set to the default widget store, if any'() {
 				let actual: { [p: string]: any } = null;
 				const store = createStore();
-				const app = createApp({ defaultStore: store });
+				const app = createApp({ defaultWidgetStore: store });
 				app.loadDefinition({
 					widgets: [
 						{
@@ -549,9 +549,9 @@ registerSuite({
 				});
 			},
 
-			'the definition\'s stateFrom option takes precedence over the default store, if any'() {
+			'the definition\'s stateFrom option takes precedence over the default widget store, if any'() {
 				let actual: { [p: string]: any } = null;
-				const app = createApp({ defaultStore: createStore() });
+				const app = createApp({ defaultWidgetStore: createStore() });
 				const store = createStore();
 				app.loadDefinition({
 					widgets: [


### PR DESCRIPTION
Supersedes https://github.com/dojo/app/pull/36, and depends on https://github.com/dojo/app/pull/43.

* The default store can now be assigned after the app is created, but only once
* Renames the `defaultStore` option to `defaultWidgetStore`
* Adds support for default action stores. This makes it impossible to automatically observe the (defined or default) store, so instead the store is passed to the action factories. **It is now their responsibility to observe the store** (if any). Default action stores work for registered action factories, including those from action definitions.