### PR TITLE
Migrate to TypeScript 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@
 /typings
 .baseDir.ts
 .tscache
+.tsconfig*.json
 coverage-unmapped.json
 npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ cache:
   directories:
   - node_modules
 install:
-- travis_retry npm install grunt-cli $(node -e "var deps = require('./package.json').peerDependencies;
-  for(var name in deps) process.stdout.write(name + '@' + deps[name] + ' ');")
+- travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '6.1'
+- '6'
 env:
   global:
   - BROWSERSTACK_USERNAME: dtktestaccount1

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "typings": "./dist/umd/dojo-app.d.ts",
   "peerDependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
-    "dojo-actions": "^2.0.0-alpha.5",
-    "dojo-compose": "^2.0.0-beta.7",
-    "dojo-core": "^2.0.0-alpha.9",
-    "dojo-dom": "^2.0.0-alpha.2",
-    "dojo-has": "^2.0.0-alpha.1",
-    "dojo-shim": "^2.0.0-alpha.1",
-    "dojo-widgets": "^2.0.0-alpha.4",
+    "dojo-actions": "next",
+    "dojo-compose":"next",
+    "dojo-core": "next",
+    "dojo-dom": "next",
+    "dojo-has": "next",
+    "dojo-shim": "next",
+    "dojo-widgets": "next",
     "immutable": "^3.8.1",
     "maquette": "^2.3.2"
   },
@@ -53,7 +53,7 @@
     "istanbul": "^0.4.3",
     "jsdom": "^9.2.1",
     "remap-istanbul": "^0.6.4",
-    "tslint": "^3.11.0",
-    "typescript": "^1.8.10"
+    "tslint": "next",
+    "typescript": "next"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/dojo/app.git"
   },
   "scripts": {
-    "prepublish": "grunt dist",
+    "prepublish": "grunt peerDepInstall dist",
     "test": "grunt test"
   },
   "typings": "./dist/umd/dojo-app.d.ts",
@@ -44,7 +44,7 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-dojo2": "^2.0.0-beta.9",
+    "grunt-dojo2": "^2.0.0-beta.13",
     "grunt-text-replace": "^0.4.0",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -460,7 +460,7 @@ export default function realizeCustomElements(
 		return Promise.all(attachedProjectors);
 	}).then(() => {
 		return {
-			destroy() {
+			destroy(this: Handle) {
 				this.destroy = noop;
 				for (const p of projectors) {
 					p.destroy();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
+		"noImplicitThis": true,
 		"outDir": "_build/",
 		"baseUrl": "node_modules",
 		"paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,5 +38,10 @@
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
 		"./typings/index.d.ts"
+	],
+	"exclude": [
+		"_build",
+		"dist",
+		"node_modules"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,55 +1,42 @@
 {
-	"version": "1.8.10",
+	"version": "2.0.0",
 	"compilerOptions": {
 		"declaration": false,
 		"module": "umd",
 		"noImplicitAny": true,
 		"outDir": "_build/",
+		"baseUrl": "node_modules",
+		"paths": {
+			"dojo-actions/*": [
+				"dojo-actions/dist/umd/*"
+			],
+			"dojo-compose/*": [
+				"dojo-compose/dist/umd/*"
+			],
+			"dojo-core/*": [
+				"dojo-core/dist/umd/*"
+			],
+			"dojo-dom/*": [
+				"dojo-dom/dist/umd/*"
+			],
+			"dojo-has/*": [
+				"dojo-has/dist/umd/*"
+			],
+			"dojo-shim/*": [
+				"dojo-shim/dist/umd/*"
+			],
+			"dojo-widgets/*": [
+				"dojo-widgets/dist/umd/*"
+			]
+		},
 		"removeComments": false,
 		"sourceMap": true,
 		"target": "es5",
 		"moduleResolution": "classic"
 	},
-	"filesGlob": [
-		"./typings/index.d.ts",
+	"include": [
 		"./src/**/*.ts",
-		"./tests/**/*.ts"
-	],
-	"files": [
-		"./typings/index.d.ts",
-		"./src/createApp.ts",
-		"./src/IdentityRegistry.ts",
-		"./src/lib/factories.ts",
-		"./src/lib/InstanceRegistry.ts",
-		"./src/lib/makeIdGenerator.ts",
-		"./src/lib/moduleResolver.ts",
-		"./src/lib/realizeCustomElements.ts",
-		"./src/lib/RegistryProvider.ts",
-		"./src/lib/resolveListenersMap.ts",
-		"./src/main.ts",
-		"./tests/fixtures/action-factory.ts",
-		"./tests/fixtures/action-instance.ts",
-		"./tests/fixtures/no-factory-export.ts",
-		"./tests/fixtures/no-instance-export.ts",
-		"./tests/fixtures/store-factory.ts",
-		"./tests/fixtures/store-instance.ts",
-		"./tests/fixtures/widget-factory.ts",
-		"./tests/fixtures/widget-instance.ts",
-		"./tests/functional/all.ts",
-		"./tests/intern-local.ts",
-		"./tests/intern-saucelabs.ts",
-		"./tests/intern.ts",
-		"./tests/support/createApp.ts",
-		"./tests/support/Reporter.ts",
-		"./tests/support/util.ts",
-		"./tests/unit/all.ts",
-		"./tests/unit/createApp.ts",
-		"./tests/unit/createApp/actions.ts",
-		"./tests/unit/createApp/customElements.ts",
-		"./tests/unit/createApp/realize.ts",
-		"./tests/unit/createApp/stores.ts",
-		"./tests/unit/createApp/widgets.ts",
-		"./tests/unit/IdentityRegistry.ts",
-		"./tests/unit/main.ts"
+		"./tests/**/*.ts",
+		"./typings/index.d.ts"
 	]
 }

--- a/typings.json
+++ b/typings.json
@@ -1,12 +1,6 @@
 {
 	"name": "dojo-app",
 	"globalDependencies": {
-		"dojo-actions": "npm:dojo-actions",
-		"dojo-compose": "npm:dojo-compose",
-		"dojo-core": "npm:dojo-core",
-		"dojo-dom": "npm:dojo-dom",
-		"dojo-has": "npm:dojo-has",
-		"dojo-shim": "npm:dojo-shim",
 		"extra-immutable": "github:dojo/typings/custom/dojo2-extras/immutable.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-maquette": "github:dojo/typings/custom/dojo2-extras/maquette.d.ts#004fc065b3b24412c9b6575cdc06545964c370b5",
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#6008ffd2b3a102d6f07ec5fe7a1a3cd637157757"


### PR DESCRIPTION
Assumes `dojo-widgets@next` has been published with TS2 support (which is not currently the case).

Does not yet enable `strictNullChecks`, see #45.

Fixes #23 and #46.