### PR TITLE
Dynmically create widget for the type set in state

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -915,25 +915,20 @@ const createApp = compose({
 			const factories = widgetFactories.get(this);
 			const instances = widgetInstances.get(this);
 
-			return new Promise((resolve) => {
-				// First see if a factory exists for the widget.
-				let factory: WidgetFactory;
-				try {
-					factory = factories.get(id);
-					resolve(factory());
-				} catch (missingFactory) {
-					try {
-						// Otherwise try and get an existing instance.
-						const instance = instances.get(id);
-						resolve(instance);
-					} catch (_) {
-						if (!this.defaultWidgetStore) {
-							throw missingFactory;
-						}
-						const widget = createCustomWidget(this, id).catch((e) => { throw missingFactory; });
-						resolve(widget);
-					}
-				}
+			let missingFactory: any;
+			return Promise.resolve().then(() => {
+				const factory = factories.get(id);
+				return factory();
+			})
+			.catch((e) => {
+				missingFactory = e;
+				return instances.get(id);
+			})
+			.catch((e) => {
+				return createCustomWidget(this, id);
+			})
+			.catch((e) => {
+				throw missingFactory;
 			});
 		},
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -39,6 +39,7 @@ export type ActionLike = Action<any, any, any>;
  */
 export type StoreLike = ObservableState<State> & {
 	add<T>(item: T, options?: any): Promise<T>;
+	get<T>(id: string): Promise<T>;
 }
 
 /**
@@ -512,6 +513,20 @@ function addIdentifier(app: App, id: Identifier) {
 	};
 }
 
+function createCustomWidget(app: App, id: string) {
+	const customFactories = customElementFactories.get(app);
+
+	return app.defaultWidgetStore.get(id).then((state: any) => {
+		const customFactory = customFactories.get(state.type);
+		const widgetOrPromise = customFactory( { state } );
+
+		return Promise.resolve(widgetOrPromise).then((widget) => {
+			widget.own(registerInstance(app, widget, id));
+			return widget;
+		});
+	});
+}
+
 function registerInstance(app: App, instance: WidgetLike, id: string): Handle {
 	// Maps the instance to its ID
 	const instanceHandle = instanceRegistries.get(app).addWidget(instance, id);
@@ -899,26 +914,26 @@ const createApp = compose({
 			// custom elements.
 			const factories = widgetFactories.get(this);
 			const instances = widgetInstances.get(this);
+
 			return new Promise((resolve) => {
 				// First see if a factory exists for the widget.
 				let factory: WidgetFactory;
 				try {
 					factory = factories.get(id);
+					resolve(factory());
 				} catch (missingFactory) {
 					try {
 						// Otherwise try and get an existing instance.
 						const instance = instances.get(id);
 						resolve(instance);
-						return; // Make sure to return!
 					} catch (_) {
-						// Don't confuse people by complaining about missing instances, rethrow the
-						// original error.
-						throw missingFactory;
+						if (!this.defaultWidgetStore) {
+							throw missingFactory;
+						}
+						const widget = createCustomWidget(this, id).catch((e) => { throw missingFactory; });
+						resolve(widget);
 					}
 				}
-				// This is only reached when a factory exists. Call it and resolve with the result.
-				// If it throws that's fine, it'll reject the promise.
-				resolve(factory());
 			});
 		},
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -515,10 +515,12 @@ function addIdentifier(app: App, id: Identifier) {
 
 function createCustomWidget(app: App, id: string) {
 	const customFactories = customElementFactories.get(app);
+	const { registryProvider, defaultActionStore: stateFrom } = app;
 
 	return app.defaultWidgetStore.get(id).then((state: any) => {
+		const options: any = { id, stateFrom, registryProvider, state };
 		const customFactory = customFactories.get(state.type);
-		const widgetOrPromise = customFactory( { state } );
+		const widgetOrPromise = customFactory(options);
 
 		return Promise.resolve(widgetOrPromise).then((widget) => {
 			widget.own(registerInstance(app, widget, id));

--- a/tests/support/createApp.ts
+++ b/tests/support/createApp.ts
@@ -1,6 +1,7 @@
 import Promise from 'dojo-shim/Promise';
 import * as assert from 'intern/chai!assert';
 import compose from 'dojo-compose/compose';
+import Map from 'dojo-shim/Map';
 import { h } from 'maquette';
 import { Handle } from 'dojo-core/interfaces';
 
@@ -23,9 +24,17 @@ export function createStore(): StoreLike {
 export const createSpyStore = compose({
 	add(this: any, ...args: any[]): Promise<any> {
 		this._add.push(args);
+		const id = args ? args[0].id : null;
+		if (id) {
+			this._map.set(id, args[0]);
+		}
 		return Promise.resolve({});
 	},
+	get(this: any, id: string): Promise<any> {
+		return Promise.resolve(this._map.get(id));
+	},
 	_add: <any[][]> null,
+	_map: <Map<string, any>> null,
 	observe(...args: any[]): any {},
 	_observe: <any[][]> null,
 	patch(this: any, ...args: any[]): Promise<any> {
@@ -37,6 +46,7 @@ export const createSpyStore = compose({
 }, (instance, options) => {
 	instance._options = options;
 	instance._add = [];
+	instance._map = new Map<string, any>();
 	instance._observe = [];
 	instance._patch = [];
 });
@@ -66,6 +76,12 @@ export const createSpyWidget = compose({
 	instance._options = options;
 	instance._own = [];
 });
+
+export function createAsyncSpyWidget(): Promise<WidgetLike> {
+	return new Promise<WidgetLike>((resolve) => {
+		resolve(createSpyWidget());
+	});
+}
 
 export function invert(promise: Promise<any>): Promise<any> {
 	return promise.then((value) => {

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -16,6 +16,7 @@ import {
 	createAction,
 	createStore,
 	createWidget,
+	createAsyncSpyWidget,
 	createSpyStore,
 	createSpyWidget,
 	invert,
@@ -40,6 +41,41 @@ registerSuite({
 			app.registerWidget('foo', expected);
 
 			return strictEqual(app.getWidget('foo'), expected);
+		},
+
+		'creates and provides widget using factory registered for the states custom type'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			app.registerCustomElementFactory('custom-element', createSpyWidget);
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				return app.getWidget('foo').then((widget) => {
+					assert.isObject(widget);
+				});
+			});
+		},
+
+		'no registered factory for the widget state type'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				return rejects(app.getWidget('foo'), Error);
+			});
+		},
+
+		'creates (async) and provides widget using factory registered for the states custom type'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			app.registerCustomElementFactory('custom-element', createAsyncSpyWidget);
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				return app.getWidget('foo').then((widget) => {
+					assert.isObject(widget);
+				});
+			});
 		}
 	},
 

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -56,15 +56,6 @@ registerSuite({
 			});
 		},
 
-		'no registered factory for the widget state type'() {
-			const defaultWidgetStore = createSpyStore();
-			const app = createApp({ defaultWidgetStore });
-
-			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
-				return rejects(app.getWidget('foo'), Error);
-			});
-		},
-
 		'creates (async) and provides widget using factory registered for the states custom type'() {
 			const defaultWidgetStore = createSpyStore();
 			const app = createApp({ defaultWidgetStore });
@@ -75,6 +66,37 @@ registerSuite({
 				return app.getWidget('foo').then((widget) => {
 					assert.isObject(widget);
 				});
+			});
+		},
+
+		'no registered factory for the widget state type'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				return rejects(app.getWidget('foo'), Error);
+			});
+		},
+
+		'no default widget store'() {
+			const app = createApp();
+
+			return rejects(app.getWidget('foo'), Error);
+		},
+
+		'no state record for id'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			return rejects(app.getWidget('foo'), Error);
+		},
+
+		'no type on state record'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			return defaultWidgetStore.add({id: 'foo'}).then(() => {
+				return rejects(app.getWidget('foo'), Error);
 			});
 		}
 	},


### PR DESCRIPTION
**Type:** feature

**Description:** 

Support dynamically creating widgets based on the `type` set in the defaultWidgetStore when an instance or specific factory are not available for the passed `id` to `getWidget`

**Related Issue:** #54 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged