### PR TITLE
Refactor getWidget() again

### DIFF
--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -87,6 +87,19 @@ registerSuite({
 			});
 		},
 
+		'is rejected with the error thrown by the widget factory'() {
+			const expected = new Error();
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			app.registerCustomElementFactory('custom-element', createSpyWidget);
+			app.registerWidgetFactory('foo', () => { throw expected; });
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				return strictEqual(rejects(app.getWidget('foo'), Error), expected);
+			});
+		},
+
 		'no registered factory for the widget state type'() {
 			const defaultWidgetStore = createSpyStore();
 			const app = createApp({ defaultWidgetStore });


### PR DESCRIPTION
Follow-up to #59.

Add a test to verify that errors caused by calling factory are
propagated, without creating a custom widget. This test fails with the
original implementation in #55.

Restore most of the promise chaining from #55, which is more readable
than the nested try/catch statements.

Retain the defaultWidgetStore guard introduced in #59, but acknowledge
that errors thrown by createCustomWidget are masked. In other words,
remove the very subtle control flow that allowed createCustomWidget
errors to bubble up to the calling code. This may hide bugs but should
generally be OK.