### PR TITLE
Extract refactoring from #39

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ app.registerCustomElementFactory('tag-name', createWidget);
 
 A factory for a custom element should return a unique widget instance. It receives an `options` object with an optional `id` property and other options from the custom element.
 
-Tag names must be [valid according to the Custom Elements spec](https://www.w3.org/TR/custom-elements/#valid-custom-element-name). Additionally `app-projector` and `app-widget` names are reserved. Names are automatically lowercased before the factory is registered.
+Tag names must be [valid according to the Custom Elements spec](https://www.w3.org/TR/custom-elements/#valid-custom-element-name). Additionally names starting with `app-` are reserved. Names are automatically lowercased before the factory is registered.
 
 ### Registering stores
 
@@ -298,7 +298,7 @@ Note that if an action, store or widget instance is provided to the `instance` o
 
 The application factory must be loaded with [`dojo-loader`](https://github.com/dojo/loader) in order to resolve module identifiers. Both ES and UMD modules are supported. The default export is used as the `factory` or `instance` value.
 
-Custom element definitions must have a `name` property, which must be a [valid custom element name](https://www.w3.org/TR/custom-elements/#valid-custom-element-name) (and not `app-projector` or `app-widget`). They must also have the `factory` property, but *not* the `id` and `instance` properties
+Custom element definitions must have a `name` property, which must be a [valid custom element name](https://www.w3.org/TR/custom-elements/#valid-custom-element-name) (and not start with `app-`). They must also have the `factory` property, but *not* the `id` and `instance` properties
 
 #### Action definitions
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ If you use your own factory method you can use the `stateFrom` option in the act
 
 If the `stateFrom` option is not used, but a default action store is provided, that default action store will be passed to the factory.
 
+Use the `state` property to define an initial state that is added to the actions's store before the action is created, if any. This will be done lazily once the action is needed. The store is assumed to reject the initial state if it already contains state for the action. This error will be ignored and the action will be created with whatever state was already in the store.
+
 #### Store definitions
 
 If you use `factory` in your store definition you can use the `options` property to specify an object that is passed when the factory is called.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ app.registerAction('my-action', action);
 You can also register a factory method which creates the action only when needed:
 
 ```ts
-app.registerActionFactory('my-lazy-action', () => {
+app.registerActionFactory('my-lazy-action', (options) => {
 	return createAction({
 		do() {
 			// something else
@@ -78,7 +78,7 @@ app.registerActionFactory('my-lazy-action', () => {
 
 Note that an action instance may only be registered once. A factory is not allowed to return a previously registered instance.
 
-The factory is called with a registry object and potentially a default action store. The registry object contains the same `has*()` and `get*()` methods that are available on the application factory itself.
+The `options` object may have a `stateFrom` property, set to the default action store. A [registry provider](#registry-providers) is available under the `registryProvider` property.
 
 ### Registering custom element factories
 
@@ -219,14 +219,14 @@ app.registerAction('my-action', myAction);
 
 However if the action needs to access a store that is lazily loaded you'd then need a reference to the application factory in order to access the store.
 
-To make this easier the application factory calls `configure()` on actions after they've been loaded. The configuration object contains the same `has*()` and `get*()` methods that are available on the application factory itself.
+To make this easier the application factory calls `configure()` on actions after they've been loaded. The configuration object is the [registry provider](#registry-providers).
 
 For example, to store a reference to a particular store, you could do:
 
 ```ts
 // my-action.ts
 import createAction from 'dojo-actions/createAction';
-import { CombinedRegistry } from 'dojo-app/createApp';
+import { RegistryProvider } from 'dojo-app/createApp';
 import { MemoryStore } from 'dojo-widgets/util/createMemoryStore';
 
 interface MyAction {
@@ -234,8 +234,8 @@ interface MyAction {
 }
 
 export default createAction.extend<MyAction>({})({
-	configure(registry: CombinedRegistry) {
-		return registry.getStore('my-store').then((store) => {
+	configure(registryProvider: RegistryProvider) {
+		return registryProvider.get('stores').get('my-store').then((store) => {
 			(<MyAction> this).store = store;
 		});
 	},
@@ -252,18 +252,18 @@ If you registered an action factory you can do something similar, without having
 ```ts
 // my-action-factory.ts
 import createAction from 'dojo-actions/createAction';
-import { CombinedRegistry } from 'dojo-app/createApp';
+import { ActionFactory } from 'dojo-app/createApp';
 import { MemoryStore } from 'dojo-widgets/util/createMemoryStore';
 
-export default function(registry: CombinedRegistry) {
-	return registry.getStore('my-store').then((store) => {
+export default (function({ registryProvider }) {
+	return registryProvider.get('stores').get('my-store').then((store) => {
 		return createAction({
 			do() {
 				return (<MemoryStore<Object>> store).patch({ id: 'some-object', value: 'some-value' });
 			}
 		});
 	});
-}
+} as ActionFactory);
 ```
 
 ### Describing applications
@@ -360,7 +360,7 @@ Note that destroying handles will not destroy any action, store or widget instan
 
 ### Registry providers
 
-The registry provider can provide read-only registries for actions, stores and widgets. It's available under `app.registryProvider` and passed to widget factories as the `registryProvider` option.
+The registry provider can provide read-only registries for actions, stores and widgets. It's available under `app.registryProvider`, passed to action and widget factories as the `registryProvider` option, and used when configuring actions.
 
 Use `registryProvider.get('actions')` to get an action registry. `registryProvider.get('stores')` gives you a store registry, and `registryProvider.get('widgets')` a widget registry.
 

--- a/README.md
+++ b/README.md
@@ -376,11 +376,13 @@ All descending custom elements are replaced by rendered widgets. Widgets for nes
 
 Custom elements are matched (case-insensitively) to registered factories. First the tag name is matched. If no factory is found, and the element has an `is` attribute, that value is used to find a factory. Unrecognized elements are left in the DOM where possible.
 
-A factory options object can be provided in the DOM by setting the `data-options` attribute to a JSON string. The options object may have a `stateFrom` property containing a store identifier. It may also have a `listeners` property containing a widget listener map. Values for each event type can be action identifiers or arrays thereof. These properties are resolved to the actual store and action instances before the factory is called. Additional properties are passed to the factory as-is.
+A factory options object can be provided in the DOM by setting the `data-options` attribute to a JSON string. The options object must not have an `id` property, instead the `data-uid` or `id` attribute should be used. It also must not have a `stateFrom` property, the `data-state-from` should be used instead. Similarly use the `data-listeners` attribute instead of the `listeners` property, and the `data-state` attribute instead of the `state` property.
 
-Widgets can be identified through the `id` property on the options object, a `data-uid` attribute, or an `id` attribute. The options object takes precedence over the `data-uid` attribute, which takes precedence over the `id` attribute. It's valid to use the different attributes, but only the most specific ID will be passed to the factory (in the `options` object).
+Widgets can be identified through a `data-uid` or `id` attribute. The `data-uid` attribute takes precedence over the `id` attribute. It's valid to use the different attributes, but only the most specific ID will be passed to the factory (in its `options` object).
 
-The `data-state-from` attribute may be used on custom elements to specify a store identifier. This will only take effect if a widget ID is also specified. The `stateFrom` property on the options object that is passed to the factory will be set to the referenced store. Any `stateFrom` property in the `data-options` object still takes precedence.
+The `data-listeners` attribute may be used to specify a widget listener map. Values for each event type can be action identifiers or arrays thereof. These properties are resolved to the actual store and action instances before the factory is called. Additional properties are passed to the factory as-is.
+
+The `data-state-from` attribute may be used on custom elements to specify a store identifier. This will only take effect if a widget ID is also specified. The `stateFrom` property on the options object that is passed to the factory will be set to the referenced store.
 
 A default widget store may be configured by setting the `data-state-from` attribute on the `app-projector` custom element. It applies to all descendant elements that have IDs, though they can override it by setting their own `data-state-from` attribute or configuring `stateFrom` in their `data-options`.
 
@@ -444,7 +446,7 @@ And this `<body>`:
 	<app-projector>
 		<div>
 			<dojo-container>
-				<a-widget data-options='{"id":"widget-1","tagName":"mark","stateFrom":"widget-state","listeners":{"click":"an-action"}}'></a-widget>
+				<a-widget data-uid="widget-1" data-options='{"tagName":"mark"}' data-listeners='{"click":"an-action"}' data-state-from="widget-state"></a-widget>
 				<div>
 					<div is="app-widget" id="widget-2"></div>
 				</div>

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -643,7 +643,7 @@ const createApp = compose({
 
 	registerCustomElementFactory(this: App, name: string, factory: WidgetFactory): Handle {
 		if (!isValidName(name)) {
-			throw new SyntaxError(`'${name}' is not a valid custom element name'`);
+			throw new SyntaxError(`'${name}' is not a valid custom element name`);
 		}
 
 		// Wrap the factory since the registry cannot store frozen factories, and dojo-compose creates

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -361,8 +361,9 @@ export interface AppMixin {
 	/**
 	 * Register an action factory with the app.
 	 *
-	 * The factory will be called the first time the action is needed. It'll be called with *one* argument:
-	 * the combined registries of the app.
+	 * The factory will be called the first time the action is needed. It'll be called with at least one argument:
+	 * the combined registries of the app. The second argument may be the store that was defined for this action. It's
+	 * the factories responsibility to create an action that observes the store.
 	 *
 	 * Note that the `createAction()` factory from `dojo-actions` cannot be used here since it requires you to define
 	 * the `do()` implementation, which the app factory does not allow.
@@ -419,7 +420,8 @@ export interface AppMixin {
 	 * Register a widget factory with the app.
 	 *
 	 * The factory will be called the first time the widget is needed. It'll be called with an options object
-	 * that has its `id` property set to the widget ID.
+	 * that has its `id` property set to the widget ID, and a `registryProvider` property containing a RegistryProvider
+	 * implementation for the app. If a default widget store is available it'll be passed as the `stateFrom` property.
 	 *
 	 * @param id How the widget is identified
 	 * @param factory A factory function that (asynchronously) creates a widget.

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -234,9 +234,11 @@ export interface WidgetListenersMap {
 }
 
 /**
- * Read-only interface for the combined registries of the app factory.
+ * Read-only interface to access actions, custom element factories, stores and widgets.
+ *
+ * Used in helper modules which shouldn't write to the app registry.
  */
-export interface CombinedRegistry {
+export interface ReadOnlyRegistry {
 	/**
 	 * Get the action with the given identifier.
 	 *
@@ -467,7 +469,7 @@ export interface AppMixin {
 	realize(root: Element): Promise<Handle>;
 }
 
-export type App = AppMixin & CombinedRegistry;
+export type App = AppMixin & ReadOnlyRegistry;
 
 export interface AppOptions {
 	/**

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -513,7 +513,6 @@ const widgetFactories = new WeakMap<App, IdentityRegistry<RegisteredFactory<Widg
 
 const instanceRegistries = new WeakMap<App, InstanceRegistry>();
 const midResolvers = new WeakMap<App, ResolveMid>();
-const publicRegistries = new WeakMap<App, CombinedRegistry>();
 const registryProviders = new WeakMap<App, RegistryProvider>();
 const widgetInstances = new WeakMap<App, IdentityRegistry<WidgetLike>>();
 
@@ -852,7 +851,7 @@ const createApp = compose({
 			this.defaultWidgetStore,
 			(id) => addIdentifier(this, id),
 			(instance: WidgetLike, id: string) => registerInstance(this, instance, id),
-			publicRegistries.get(this),
+			this,
 			this.registryProvider,
 			root
 		);
@@ -904,7 +903,7 @@ const createApp = compose({
 
 			function configureWidget(): Promise<any> | void {
 				// Ensure no other widget with this ID exists.
-				if (publicRegistries.get(app).hasWidget(id)) {
+				if (app.hasWidget(id)) {
 					return Promise.reject(new Error(`A widget with ID '${id}' already exists`));
 				}
 
@@ -998,22 +997,6 @@ const createApp = compose({
 			toAbsMid = (moduleId: string) => moduleId
 		}: AppOptions = {}
 	) {
-		const publicRegistry = {
-			getAction: instance.getAction.bind(instance),
-			hasAction: instance.hasAction.bind(instance),
-			identifyAction: instance.identifyAction.bind(instance),
-			getCustomElementFactory: instance.getCustomElementFactory.bind(instance),
-			hasCustomElementFactory: instance.hasCustomElementFactory.bind(instance),
-			getStore: instance.getStore.bind(instance),
-			hasStore: instance.hasStore.bind(instance),
-			identifyStore: instance.identifyStore.bind(instance),
-			createWidget: instance.createWidget.bind(instance),
-			getWidget: instance.getWidget.bind(instance),
-			hasWidget: instance.hasWidget.bind(instance),
-			identifyWidget: instance.identifyWidget.bind(instance)
-		};
-		Object.freeze(publicRegistry);
-
 		actionFactories.set(instance, new IdentityRegistry<RegisteredFactory<ActionLike>>());
 		customElementFactories.set(instance, new IdentityRegistry<RegisteredFactory<WidgetLike>>());
 		identifiers.set(instance, new Set<Identifier>());
@@ -1022,8 +1005,7 @@ const createApp = compose({
 
 		instanceRegistries.set(instance, new InstanceRegistry());
 		midResolvers.set(instance, makeMidResolver(toAbsMid));
-		publicRegistries.set(instance, publicRegistry);
-		registryProviders.set(instance, new RegistryProvider(publicRegistry));
+		registryProviders.set(instance, new RegistryProvider(instance));
 		widgetInstances.set(instance, new IdentityRegistry<WidgetLike>());
 
 		if (defaultActionStore) {

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -133,6 +133,11 @@ export interface ItemDefinition<Factory, Instance> {
  */
 export interface ActionDefinition extends ItemDefinition<ActionFactory, ActionLike> {
 	/**
+	 * Initial state, to be added to the action's store, if any.
+	 */
+	state?: any;
+
+	/**
 	 * Identifier of a store which the action should observe for its state.
 	 *
 	 * When the action is created it'll automatically observe this store.

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -47,15 +47,29 @@ export type StoreLike = ObservableState<State> & {
 export type WidgetLike = Child;
 
 /**
+ * Options passed to action factories.
+ */
+export interface ActionFactoryOptions {
+	/**
+	 * Provides access to read-only registries for actions, stores and widgets.
+	 */
+	registryProvider: RegistryProvider;
+
+	/**
+	 * The store that was defined for this action.
+	 *
+	 * It's the factories responsibility to create an action that observes the store.
+	 */
+	stateFrom?: StoreLike;
+}
+
+/**
  * Factory method to (asynchronously) create an action.
  *
- * @param registry The combined registries of the app
- * @param store The store that was defined for this action. It's the factories responsibility to create an action that
- *   observes the store
  * @return The action, or a promise for it
  */
 export interface ActionFactory {
-	(registry: CombinedRegistry, store: StoreLike): ActionLike | Promise<ActionLike>;
+	(options: ActionFactoryOptions): ActionLike | Promise<ActionLike>;
 }
 
 /**
@@ -366,9 +380,10 @@ export interface AppMixin {
 	/**
 	 * Register an action factory with the app.
 	 *
-	 * The factory will be called the first time the action is needed. It'll be called with at least one argument:
-	 * the combined registries of the app. The second argument may be the store that was defined for this action. It's
-	 * the factories responsibility to create an action that observes the store.
+	 * The factory will be called the first time the action is needed. It'll be called with an options object that has
+	 * a `registryProvider` property containing a RegistryProvider implementation for the app. If a default action store
+	 * is available it'll be passed as the `stateFrom` property. It's the factories responsibility to create an action
+	 * that observes the store.
 	 *
 	 * Note that the `createAction()` factory from `dojo-actions` cannot be used here since it requires you to define
 	 * the `do()` implementation, which the app factory does not allow.
@@ -437,8 +452,7 @@ export interface AppMixin {
 	/**
 	 * Load a POJO definition containing actions, stores and widgets that need to be registered.
 	 *
-	 * Action factories will be called with one argument: the combined registries of the app.
-	 * Store and widget factories will also be called with one argument: an options object.
+	 * All factories will be called with an options object.
 	 *
 	 * @return A handle to deregister *all* actions, stores and widgets that were registered.
 	 */
@@ -589,7 +603,7 @@ const createApp = compose({
 
 		let registryHandle = actionFactories.get(this).register(id, () => {
 			const promise = new Promise<void>((resolve) => {
-				resolve(action.configure(publicRegistries.get(this)));
+				resolve(action.configure(this.registryProvider));
 			})
 			.then(() => action);
 
@@ -621,7 +635,8 @@ const createApp = compose({
 					// Always call the factory in a future turn. This harmonizes behavior regardless of whether the
 					// factory is registered through this method or loaded from a definition.
 
-					return factory(publicRegistries.get(this), this.defaultActionStore);
+					const { defaultActionStore: stateFrom, registryProvider } = this;
+					return factory({ registryProvider, stateFrom });
 				})
 				.then((action) => {
 					if (!destroyed) {
@@ -629,7 +644,7 @@ const createApp = compose({
 					}
 
 					// Configure the action, allow for a promise to be returned.
-					return Promise.resolve(action.configure(publicRegistries.get(this))).then(() => {
+					return Promise.resolve(action.configure(this.registryProvider)).then(() => {
 						return action;
 					});
 				});
@@ -793,7 +808,7 @@ const createApp = compose({
 
 		if (actions) {
 			for (const definition of actions) {
-				const factory = makeActionFactory(definition, midResolvers.get(this));
+				const factory = makeActionFactory(definition, midResolvers.get(this), this);
 				const handle = this.registerActionFactory(definition.id, factory);
 				handles.push(handle);
 			}

--- a/src/lib/RegistryProvider.ts
+++ b/src/lib/RegistryProvider.ts
@@ -7,6 +7,7 @@ import {
 	Identifier,
 	ReadOnlyRegistry,
 	StoreLike,
+	WidgetFactoryOptions,
 	WidgetLike
 } from '../createApp';
 
@@ -38,7 +39,10 @@ interface UnderlyingRegistry {
 	identifyAction(action: ActionLike): Identifier;
 	getStore(id: Identifier | symbol): Promise<StoreLike>;
 	identifyStore(store: StoreLike): Identifier | symbol;
-	createWidget<U extends Child, O>(factory: ComposeFactory<U, O>, options?: O): Promise<[string, U]>;
+	createWidget<
+		U extends Child,
+		O extends WidgetFactoryOptions
+	>(factory: ComposeFactory<U, O>, options?: O): Promise<[string, U]>;
 	getWidget(id: Identifier): Promise<WidgetLike>;
 	identifyWidget(widget: WidgetLike): Identifier;
 }

--- a/src/lib/RegistryProvider.ts
+++ b/src/lib/RegistryProvider.ts
@@ -4,8 +4,8 @@ import { Child } from 'dojo-widgets/mixins/interfaces';
 
 import {
 	ActionLike,
-	CombinedRegistry,
 	Identifier,
+	ReadOnlyRegistry,
 	StoreLike,
 	WidgetLike
 } from '../createApp';
@@ -68,15 +68,15 @@ export default class RegistryProvider {
 	private widgetRegistry: WidgetRegistry<Identifier, WidgetLike>;
 
 	private underlyingRegistry: UnderlyingRegistry;
-	constructor(combinedRegistry: CombinedRegistry) {
+	constructor(registry: ReadOnlyRegistry) {
 		this.underlyingRegistry = Object.freeze({
-			getAction: combinedRegistry.getAction.bind(combinedRegistry),
-			identifyAction: combinedRegistry.identifyAction.bind(combinedRegistry),
-			getStore: combinedRegistry.getStore.bind(combinedRegistry),
-			identifyStore: combinedRegistry.identifyStore.bind(combinedRegistry),
-			createWidget: combinedRegistry.createWidget.bind(combinedRegistry),
-			getWidget: combinedRegistry.getWidget.bind(combinedRegistry),
-			identifyWidget: combinedRegistry.identifyWidget.bind(combinedRegistry)
+			getAction: registry.getAction.bind(registry),
+			identifyAction: registry.identifyAction.bind(registry),
+			getStore: registry.getStore.bind(registry),
+			identifyStore: registry.identifyStore.bind(registry),
+			createWidget: registry.createWidget.bind(registry),
+			getWidget: registry.getWidget.bind(registry),
+			identifyWidget: registry.identifyWidget.bind(registry)
 		});
 	}
 

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -9,12 +9,12 @@ import {
 	CustomElementDefinition,
 	ItemDefinition,
 	ReadOnlyRegistry,
-	RegistryProvider,
 	StoreDefinition,
 	StoreFactory,
 	StoreLike,
 	WidgetDefinition,
 	WidgetFactory,
+	WidgetFactoryOptions,
 	WidgetLike
 } from '../createApp';
 import { ResolveMid } from './moduleResolver';
@@ -146,7 +146,7 @@ export function makeActionFactory(definition: ActionDefinition, resolveMid: Reso
 export function makeCustomElementFactory(definition: CustomElementDefinition, resolveMid: ResolveMid): WidgetFactory {
 	let promise: Promise<void>;
 	let factory: WidgetFactory;
-	return (options: Object) => {
+	return (options: WidgetFactoryOptions) => {
 		if (factory) {
 			return factory(options);
 		}
@@ -211,19 +211,9 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 		}
 	}
 
-	interface BaseOptions {
-		registryProvider: RegistryProvider;
-		stateFrom?: StoreLike;
-	}
-
-	return ({ registryProvider, stateFrom: defaultWidgetStore }: BaseOptions) => {
-		interface Options extends BaseOptions {
-			id: string;
-			listeners?: EventedListenersMap;
-		}
-
+	return ({ registryProvider, stateFrom: defaultWidgetStore }: WidgetFactoryOptions) => {
 		const { id, state: initialState } = definition;
-		const options: Options = assign({
+		const options: WidgetFactoryOptions = assign({
 			id,
 			registryProvider
 		}, rawOptions);

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -71,36 +71,40 @@ function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition 
 	if (typeof factory === 'function') {
 		return Promise.resolve(factory);
 	}
-
-	if (isInstance(instance)) {
+	else if (isInstance(instance)) {
 		// <any> hammer since TypeScript can't resolve match the correct overloaded Instance type with the correct
 		// Factory return value.
 		const factory: Factory = () => <any> instance;
 		return Promise.resolve(factory);
 	}
-
-	const mid = <string> (factory || instance);
-	return resolveMid(mid).then((defaultExport) => {
-		if (factory) {
-			if (typeof defaultExport !== 'function') {
-				throw new Error(`Could not resolve '${mid}' to ${errorStrings[type]} factory function`);
+	else {
+		return new Promise((resolve, reject) => {
+			if (instance) {
+				resolveMid<Instance>(instance)
+					.then((defaultExport) => {
+						if (!defaultExport || typeof defaultExport !== 'object') {
+							reject(new Error(`Could not resolve '${instance}' to ${errorStrings[type]} instance`));
+						}
+						else {
+							resolve(() => defaultExport);
+						}
+					})
+					.catch(reject);
 			}
-
-			const factory: Factory = defaultExport;
-			return factory;
-		}
-
-		// istanbul ignore else Action factories are expected to guard against definitions with neither
-		// factory or instance properties.
-		if (instance) {
-			if (!defaultExport || typeof defaultExport !== 'object') {
-				throw new Error(`Could not resolve '${mid}' to ${errorStrings[type]} instance`);
+			else {
+				resolveMid<Factory>(factory)
+					.then((defaultExport) => {
+						if (typeof defaultExport !== 'function') {
+							reject(new Error(`Could not resolve '${factory}' to ${errorStrings[type]} factory function`));
+						}
+						else {
+							resolve(defaultExport);
+						}
+					})
+					.catch(reject);
 			}
-
-			const instance: Instance = defaultExport;
-			return () => instance;
-		}
-	});
+		});
+	}
 }
 
 export function makeActionFactory(definition: ActionDefinition, resolveMid: ResolveMid): ActionFactory {

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -107,7 +107,7 @@ function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition 
 	}
 }
 
-export function makeActionFactory(definition: ActionDefinition, resolveMid: ResolveMid): ActionFactory {
+export function makeActionFactory(definition: ActionDefinition, resolveMid: ResolveMid, registry: CombinedRegistry): ActionFactory {
 	if (!('factory' in definition || 'instance' in definition)) {
 		throw new TypeError('Action definitions must specify either the factory or instance option');
 	}
@@ -121,7 +121,7 @@ export function makeActionFactory(definition: ActionDefinition, resolveMid: Reso
 	}
 
 	const { id, state: initialState } = definition;
-	return (registry: CombinedRegistry, defaultActionStore: StoreLike) => {
+	return ({ registryProvider, stateFrom: defaultActionStore }) => {
 		return Promise.all<any>([
 			resolveFactory('action', definition, resolveMid),
 			resolveStore(registry, definition)
@@ -129,14 +129,16 @@ export function makeActionFactory(definition: ActionDefinition, resolveMid: Reso
 			const factory = <ActionFactory> _factory;
 			const store = <StoreLike> _store || defaultActionStore;
 
+			const options = { registryProvider, stateFrom: store };
+
 			if (store && initialState) {
 				return store.add(initialState, { id })
 					// Ignore error, assume store already contains state for this widget.
 					.catch(() => {})
-					.then(() => factory(registry, store));
+					.then(() => factory(options));
 			}
 
-			return factory(registry, store);
+			return factory(options);
 		});
 	};
 }

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -6,9 +6,9 @@ import {
 	ActionDefinition,
 	ActionFactory,
 	ActionLike,
-	CombinedRegistry,
 	CustomElementDefinition,
 	ItemDefinition,
+	ReadOnlyRegistry,
 	RegistryProvider,
 	StoreDefinition,
 	StoreFactory,
@@ -20,7 +20,7 @@ import {
 import { ResolveMid } from './moduleResolver';
 import resolveListenersMap from './resolveListenersMap';
 
-function resolveStore(registry: CombinedRegistry, definition: ActionDefinition | WidgetDefinition): void | StoreLike | Promise<StoreLike> {
+function resolveStore(registry: ReadOnlyRegistry, definition: ActionDefinition | WidgetDefinition): void | StoreLike | Promise<StoreLike> {
 	const { stateFrom } = definition;
 	if (!stateFrom) {
 		return null;
@@ -107,7 +107,7 @@ function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition 
 	}
 }
 
-export function makeActionFactory(definition: ActionDefinition, resolveMid: ResolveMid, registry: CombinedRegistry): ActionFactory {
+export function makeActionFactory(definition: ActionDefinition, resolveMid: ResolveMid, registry: ReadOnlyRegistry): ActionFactory {
 	if (!('factory' in definition || 'instance' in definition)) {
 		throw new TypeError('Action definitions must specify either the factory or instance option');
 	}
@@ -182,7 +182,7 @@ export function makeStoreFactory(definition: StoreDefinition, resolveMid: Resolv
 	};
 }
 
-export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: ResolveMid, registry: CombinedRegistry): WidgetFactory {
+export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: ResolveMid, registry: ReadOnlyRegistry): WidgetFactory {
 	if (!('factory' in definition || 'instance' in definition)) {
 		throw new TypeError('Widget definitions must specify either the factory or instance option');
 	}

--- a/src/lib/moduleResolver.ts
+++ b/src/lib/moduleResolver.ts
@@ -4,7 +4,7 @@ import Promise from 'dojo-shim/Promise';
  * Internal interface to asynchronously resolve a module by its identifier.
  */
 export interface ResolveMid {
-	(mid: string): Promise<any>;
+	<T>(mid: string): Promise<T>;
 }
 
 /**
@@ -15,7 +15,7 @@ export interface ToAbsMid {
 }
 
 export default function makeResolver(toAbsMid: ToAbsMid): ResolveMid {
-	return function resolveMid(mid: string): Promise<any> {
+	return function resolveMid<T>(mid: string): Promise<T> {
 		return new Promise((resolve) => {
 			// Assumes require() is an AMD loader!
 			require([toAbsMid(mid)], (module) => {

--- a/src/lib/parseJsonAttribute.ts
+++ b/src/lib/parseJsonAttribute.ts
@@ -1,0 +1,13 @@
+export default function parseJsonAttribute<O extends Object>(name: string, value: string): O {
+	let object: O;
+	try {
+		object = JSON.parse(value);
+	}
+	catch (err) {
+		throw new SyntaxError(`Invalid ${name}: ${err.message} (in ${JSON.stringify(value)})`);
+	}
+	if (!object || typeof object !== 'object') {
+		throw new TypeError(`Expected object from ${name} (in ${JSON.stringify(value)})`);
+	}
+	return object;
+}

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -15,6 +15,7 @@ import {
 	WidgetLike
 } from '../createApp';
 import makeIdGenerator from './makeIdGenerator';
+import parseJsonAttribute from './parseJsonAttribute';
 import resolveListenersMap from './resolveListenersMap';
 
 const reservedNames = new Set([
@@ -172,18 +173,10 @@ function resolveOptions(registry: CombinedRegistry, registryProvider: RegistryPr
 		return idFromAttributes ? { id: idFromAttributes, registryProvider } : { registryProvider };
 	}
 
-	let json: JsonOptions;
-	try {
-		json = JSON.parse(str);
-	} catch (err) {
-		throw new SyntaxError(`Invalid data-options: ${err.message} (in ${JSON.stringify(str)})`);
-	}
-	if (!json || typeof json !== 'object') {
-		throw new TypeError(`Expected object from data-options (in ${JSON.stringify(str)})`);
-	}
-
+	const json = parseJsonAttribute<JsonOptions>('data-options', str);
 	// Reassign, casted to the correct interface.
 	const options = <Options> json;
+
 	if ('registryProvider' in json) {
 		throw new Error(`Unexpected registryProvider value in data-options (in ${JSON.stringify(str)})`);
 	}
@@ -262,17 +255,7 @@ function getInitialState(element: Element): Object {
 		return null;
 	}
 
-	let initialState: Object;
-	try {
-		initialState = JSON.parse(str);
-	} catch (err) {
-		throw new SyntaxError(`Invalid data-state: ${err.message} (in ${JSON.stringify(str)})`);
-	}
-	if (!initialState || typeof initialState !== 'object') {
-		throw new TypeError(`Expected object from data-state (in ${JSON.stringify(str)})`);
-	}
-
-	return initialState;
+	return parseJsonAttribute('data-state', str);
 }
 
 const generateId = makeIdGenerator('custom-element-');

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -13,7 +13,8 @@ import {
 	StoreLike,
 	WidgetFactory,
 	WidgetFactoryOptions,
-	WidgetLike
+	WidgetLike,
+	WidgetListenersMap
 } from '../createApp';
 import makeIdGenerator from './makeIdGenerator';
 import parseJsonAttribute from './parseJsonAttribute';
@@ -168,80 +169,68 @@ interface Options {
 	stateFrom?: StoreLike;
 }
 
-function resolveOptions(registry: ReadOnlyRegistry, registryProvider: RegistryProvider, element: Element, idFromAttributes: string): Options | Promise<Options> {
+function resolveListeners(registry: ReadOnlyRegistry, element: Element): Promise<EventedListenersMap> {
+	const str = element.getAttribute('data-listeners');
+	if (!str) {
+		return null;
+	}
+
+	const listeners = parseJsonAttribute<WidgetListenersMap>('data-listeners', str);
+	let valid = true;
+	// Prefer breaking a labeled loop over nesting Array#some() calls or repeating the throwing of
+	// the TypeError.
+	check: for (const eventType in listeners) {
+		const value = listeners[eventType];
+		if (Array.isArray(value)) {
+			for (const identifier of value) {
+				if (typeof identifier !== 'string') {
+					valid = false;
+					break check;
+				}
+			}
+		}
+		else if (typeof value !== 'string') {
+			valid = false;
+			break check;
+		}
+	}
+
+	if (!valid) {
+		throw new TypeError(`Expected data-listeners to be a widget listeners map with action identifiers (in ${JSON.stringify(str)})`);
+	}
+
+	return resolveListenersMap(registry, listeners);
+}
+
+function resolveOptions(registry: ReadOnlyRegistry, registryProvider: RegistryProvider, element: Element, idFromAttributes: string): Options {
 	const str = element.getAttribute('data-options') || '';
 	if (!str) {
 		return idFromAttributes ? { id: idFromAttributes, registryProvider } : { registryProvider };
 	}
 
 	const json = parseJsonAttribute<JsonOptions>('data-options', str);
-	// Reassign, casted to the correct interface.
-	const options = <Options> json;
-
+	if ('id' in json) {
+		throw new Error(`Unexpected id value in data-options (in ${JSON.stringify(str)})`);
+	}
+	if ('listeners' in json) {
+		throw new Error(`Unexpected listeners value in data-options (in ${JSON.stringify(str)})`);
+	}
 	if ('registryProvider' in json) {
 		throw new Error(`Unexpected registryProvider value in data-options (in ${JSON.stringify(str)})`);
 	}
-	options.registryProvider = registryProvider;
+	if ('state' in json) {
+		throw new Error(`Unexpected state value in data-options (in ${JSON.stringify(str)})`);
+	}
+	if ('stateFrom' in json) {
+		throw new Error(`Unexpected stateFrom value in data-options (in ${JSON.stringify(str)})`);
+	}
 
-	if (!('id' in json) && idFromAttributes) {
+	// Reassign, casted to the correct interface.
+	const options = <Options> json;
+	options.registryProvider = registryProvider;
+	if (idFromAttributes) {
 		options.id = idFromAttributes;
 	}
-
-	const promises: Promise<void>[] = [];
-
-	if ('stateFrom' in json) {
-		const { stateFrom } = json;
-		if (!stateFrom || typeof stateFrom !== 'string') {
-			throw new TypeError(`Expected stateFrom value in data-options to be a non-empty string (in ${JSON.stringify(str)})`);
-		}
-
-		promises.push(registry.getStore(stateFrom).then((store) => {
-			options.stateFrom = store;
-		}));
-	}
-
-	if ('listeners' in json) {
-		const { listeners } = json;
-
-		let valid = true;
-		if (!listeners || typeof listeners !== 'object') {
-			valid = false;
-		}
-		else {
-			// Prefer breaking a labeled loop over nesting Array#some() calls or repeating the throwing of
-			// the TypeError.
-			check: for (const eventType in listeners) {
-				const value = listeners[eventType];
-				if (Array.isArray(value)) {
-					for (const identifier of value) {
-						if (typeof identifier !== 'string') {
-							valid = false;
-							break check;
-						}
-					}
-				}
-				else if (typeof value !== 'string') {
-					valid = false;
-					break check;
-				}
-			}
-		}
-
-		if (!valid) {
-			throw new TypeError(`Expected listeners value in data-options to be a widget listeners map with action identifiers (in ${JSON.stringify(str)})`);
-		}
-
-		promises.push(resolveListenersMap(registry, listeners).then((map) => {
-			options.listeners = map;
-		}));
-	}
-
-	if (promises.length > 0) {
-		return Promise.all(promises).then(() => {
-			return options;
-		});
-	}
-
 	return options;
 }
 
@@ -326,28 +315,33 @@ export default function realizeCustomElements(
 					else {
 						promise = Promise.all<any>([
 							registry.getCustomElementFactory(custom.name),
+							resolveListeners(registry, custom.element),
 							resolveOptions(registry, registryProvider, custom.element, id),
 							resolveStateFromAttribute(registry, custom.element),
 							projectorStateFrom
-						]).then(([_factory, _options, _store, projectorStore]) => {
+						]).then(([_factory, _listeners, _options, _store, projectorStore]) => {
 							const factory: WidgetFactory = _factory;
+							const listeners: EventedListenersMap = _listeners;
 							const options: WidgetFactoryOptions = _options;
 							// `data-state-from` store of the element takes precedence, then of the projector, then
 							// the application's default widget store.
 							const store: StoreLike = _store || projectorStore || defaultWidgetStore;
 
 							id = options.id;
-							// If the widget has an ID, but stateFrom was not in its `data-options` attribute, and
-							// either its `data-state-from` attribute resolved to a store, or there is a default
-							// store, set the stateFrom option to the `data-state-from` or default widget store.
-							if (id && !options.stateFrom && store) {
-								options.stateFrom = store;
+
+							if (listeners) {
+								options.listeners = listeners;
 							}
 
-							if (id && options.stateFrom) {
+							// If the widget has an ID, and either its `data-state-from` attribute resolved to a store,
+							// or there is a default store, set the stateFrom option to the `data-state-from` or default
+							// widget store.
+							if (id && store) {
+								options.stateFrom = store;
+
 								const initialState = getInitialState(custom.element);
 								if (initialState) {
-									return options.stateFrom.add(initialState, { id })
+									return store.add(initialState, { id })
 										// Ignore error, assume store already contains state for this widget.
 										.catch(() => undefined)
 										.then(() => factory(options));

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -8,7 +8,7 @@ import { place, Position } from 'dojo-dom/dom';
 import { createProjector, Projector } from 'dojo-widgets/projector';
 
 import {
-	CombinedRegistry,
+	ReadOnlyRegistry,
 	RegistryProvider,
 	StoreLike,
 	WidgetFactory,
@@ -74,11 +74,11 @@ interface CustomElement {
 	widget?: WidgetLike;
 }
 
-function isCustomElement(registry: CombinedRegistry, name: string): boolean {
+function isCustomElement(registry: ReadOnlyRegistry, name: string): boolean {
 	return name === 'app-projector' || name === 'app-widget' || registry.hasCustomElementFactory(name);
 }
 
-function getCustomElementsByWidgetProjector(registry: CombinedRegistry, root: Element): CustomElement[] {
+function getCustomElementsByWidgetProjector(registry: ReadOnlyRegistry, root: Element): CustomElement[] {
 	const allElements: Element[] = arrayFrom(root.getElementsByTagName('*'));
 	allElements.unshift(root); // Be inclusive!
 
@@ -167,7 +167,7 @@ interface Options {
 	stateFrom?: StoreLike;
 }
 
-function resolveOptions(registry: CombinedRegistry, registryProvider: RegistryProvider, element: Element, idFromAttributes: string): Options | Promise<Options> {
+function resolveOptions(registry: ReadOnlyRegistry, registryProvider: RegistryProvider, element: Element, idFromAttributes: string): Options | Promise<Options> {
 	const str = element.getAttribute('data-options') || '';
 	if (!str) {
 		return idFromAttributes ? { id: idFromAttributes, registryProvider } : { registryProvider };
@@ -244,7 +244,7 @@ function resolveOptions(registry: CombinedRegistry, registryProvider: RegistryPr
 	return options;
 }
 
-function resolveStateFromAttribute(registry: CombinedRegistry, element: Element): Promise<StoreLike> {
+function resolveStateFromAttribute(registry: ReadOnlyRegistry, element: Element): Promise<StoreLike> {
 	const stateFrom = element.getAttribute('data-state-from');
 	return stateFrom ? registry.getStore(stateFrom) : null;
 }
@@ -277,7 +277,7 @@ export default function realizeCustomElements(
 	defaultWidgetStore: StoreLike,
 	addIdentifier: (id: string) => Handle,
 	registerInstance: (widget: WidgetLike, id: string) => Handle,
-	registry: CombinedRegistry,
+	registry: ReadOnlyRegistry,
 	registryProvider: RegistryProvider,
 	root: Element
 ): Promise<Handle> {

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -12,6 +12,7 @@ import {
 	RegistryProvider,
 	StoreLike,
 	WidgetFactory,
+	WidgetFactoryOptions,
 	WidgetLike
 } from '../createApp';
 import makeIdGenerator from './makeIdGenerator';
@@ -330,7 +331,7 @@ export default function realizeCustomElements(
 							projectorStateFrom
 						]).then(([_factory, _options, _store, projectorStore]) => {
 							const factory: WidgetFactory = _factory;
-							const options: Options = _options;
+							const options: WidgetFactoryOptions = _options;
 							// `data-state-from` store of the element takes precedence, then of the projector, then
 							// the application's default widget store.
 							const store: StoreLike = _store || projectorStore || defaultWidgetStore;

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -26,10 +26,7 @@ const reservedNames = new Set([
 	'font-face-uri',
 	'font-face-format',
 	'font-face-name',
-	'missing-glyph',
-	// These are reserved by this module.
-	'app-projector',
-	'app-widget'
+	'missing-glyph'
 ]);
 
 // According to <https://www.w3.org/TR/custom-elements/#valid-custom-element-name>.
@@ -47,6 +44,10 @@ export function isValidName(name: string): boolean {
 	}
 
 	if (reservedNames.has(name)) { // Reserved names must not be used.
+		return false;
+	}
+
+	if (/^app-/.test(name)) { // Names must not start with app-
 		return false;
 	}
 

--- a/src/lib/resolveListenersMap.ts
+++ b/src/lib/resolveListenersMap.ts
@@ -2,12 +2,12 @@ import { EventedListener, EventedListenersMap, EventedListenerOrArray, Targetted
 import Promise from 'dojo-shim/Promise';
 
 import {
-	CombinedRegistry,
+	ReadOnlyRegistry,
 	WidgetListenersMap,
 	WidgetListenerOrArray
 } from '../createApp';
 
-function resolveListeners(registry: CombinedRegistry, ref: WidgetListenerOrArray): [EventedListenerOrArray<TargettedEventObject>, Promise<EventedListenerOrArray<TargettedEventObject>>] {
+function resolveListeners(registry: ReadOnlyRegistry, ref: WidgetListenerOrArray): [EventedListenerOrArray<TargettedEventObject>, Promise<EventedListenerOrArray<TargettedEventObject>>] {
 	if (Array.isArray(ref)) {
 		let isSync = true;
 		const results: (EventedListener<TargettedEventObject> | Promise<EventedListener<TargettedEventObject>>)[] = [];
@@ -35,7 +35,7 @@ function resolveListeners(registry: CombinedRegistry, ref: WidgetListenerOrArray
 	return [undefined, registry.getAction(<string> ref)];
 }
 
-export default function resolveListenersMap(registry: CombinedRegistry, listeners: WidgetListenersMap): Promise<EventedListenersMap> {
+export default function resolveListenersMap(registry: ReadOnlyRegistry, listeners: WidgetListenersMap): Promise<EventedListenersMap> {
 	if (!listeners) {
 		return null;
 	}

--- a/tests/fixtures/action-factory.ts
+++ b/tests/fixtures/action-factory.ts
@@ -1,4 +1,4 @@
-import { ActionFactory, CombinedRegistry } from 'src/createApp';
+import { ActionFactory } from 'src/createApp';
 
 let factory: ActionFactory = null;
 
@@ -6,6 +6,6 @@ export function stub (stub: ActionFactory) {
 	factory = stub;
 }
 
-export default function (registry: CombinedRegistry) {
-	return factory(registry, null);
-}
+export default (function (options) {
+	return factory(options);
+} as ActionFactory);

--- a/tests/fixtures/amd-factory.js
+++ b/tests/fixtures/amd-factory.js
@@ -1,7 +1,7 @@
 define(function() {
 	var factory = null;
-	var wrapper = function(registry) {
-		return factory(registry);
+	var wrapper = function(options) {
+		return factory(options);
 	};
 	wrapper.stub = function(stub) {
 		factory = stub;

--- a/tests/fixtures/widget-factory.ts
+++ b/tests/fixtures/widget-factory.ts
@@ -6,6 +6,6 @@ export function stub (stub: WidgetFactory) {
 	factory = stub;
 }
 
-export default function (options: Object) {
+export default (function (options) {
 	return factory(options);
-}
+} as WidgetFactory);

--- a/tests/unit/createApp/actions.ts
+++ b/tests/unit/createApp/actions.ts
@@ -96,7 +96,7 @@ registerSuite({
 			);
 		},
 
-		'immediately calls configure() on the action'() {
+		'calls configure() on the action when it is needed'() {
 			let called = false;
 			const action = createAction();
 			action.configure = () => { called = true; };
@@ -104,7 +104,26 @@ registerSuite({
 			const app = createApp();
 			app.registerAction('foo', action);
 
-			assert.isTrue(called);
+			assert.isFalse(called);
+			return app.getAction('foo').then(() => {
+				assert.isTrue(called);
+			});
+		},
+
+		'action is only configured once'() {
+			let count = 0;
+			const action = createAction();
+			action.configure = () => { count++; };
+
+			const app = createApp();
+			app.registerAction('foo', action);
+
+			return Promise.all([
+				app.getAction('foo'),
+				app.getAction('foo')
+			]).then(() => {
+				assert.equal(count, 1);
+			});
 		},
 
 		'action.configure() is passed a combined registry'() {
@@ -115,16 +134,8 @@ registerSuite({
 			const app = createApp();
 			app.registerAction('foo', action);
 
-			isCombinedRegistry(registry);
-		},
-
-		'registerAction() does not throw if action.configure() throws'() {
-			const action = createAction();
-			action.configure = () => { throw new Error(); };
-
-			const app = createApp();
-			assert.doesNotThrow(() => {
-				app.registerAction('foo', action);
+			return app.getAction('foo').then(() => {
+				isCombinedRegistry(registry);
 			});
 		},
 

--- a/tests/unit/createApp/actions.ts
+++ b/tests/unit/createApp/actions.ts
@@ -3,7 +3,8 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
 import createApp, {
-	CombinedRegistry,
+	ActionFactoryOptions,
+	RegistryProvider,
 	StoreLike
 } from 'src/createApp';
 
@@ -18,15 +19,6 @@ import {
 } from '../../support/createApp';
 
 const { toAbsMid } = require;
-
-function isCombinedRegistry(registry: CombinedRegistry): void {
-	assert.isFunction(registry.getAction);
-	assert.isFunction(registry.hasAction);
-	assert.isFunction(registry.getStore);
-	assert.isFunction(registry.hasStore);
-	assert.isFunction(registry.getWidget);
-	assert.isFunction(registry.hasWidget);
-}
 
 registerSuite({
 	name: 'createApp (actions)',
@@ -126,16 +118,16 @@ registerSuite({
 			});
 		},
 
-		'action.configure() is passed a combined registry'() {
-			let registry: CombinedRegistry = null;
+		'action.configure() is passed the registryProvider'() {
+			let registry: RegistryProvider = null;
 			const action = createAction();
-			action.configure = (actual: CombinedRegistry) => { registry = actual; };
+			action.configure = (actual: RegistryProvider) => { registry = actual; };
 
 			const app = createApp();
 			app.registerAction('foo', action);
 
 			return app.getAction('foo').then(() => {
-				isCombinedRegistry(registry);
+				assert.strictEqual(registry, app.registryProvider);
 			});
 		},
 
@@ -280,17 +272,17 @@ registerSuite({
 			}
 		},
 
-		'factory is passed a combined registry'() {
-			let registry: CombinedRegistry = null;
+		'factory is called with an options object that has a registryProvider property'() {
+			let actual: ActionFactoryOptions = null;
 
 			const app = createApp();
-			app.registerActionFactory('foo', (actual) => {
-				registry = actual;
+			app.registerActionFactory('foo', (options) => {
+				actual = options;
 				return createAction();
 			});
 
 			return app.getAction('foo').then(() => {
-				isCombinedRegistry(registry);
+				assert.strictEqual(actual.registryProvider, app.registryProvider);
 			});
 		},
 
@@ -307,16 +299,16 @@ registerSuite({
 			});
 		},
 
-		'action.configure() is passed a combined registry'() {
-			let registry: CombinedRegistry = null;
+		'action.configure() is passed the registryProvider'() {
+			let registry: RegistryProvider = null;
 			const action = createAction();
-			action.configure = (actual: CombinedRegistry) => { registry = actual; };
+			action.configure = (actual: RegistryProvider) => { registry = actual; };
 
 			const app = createApp();
 			app.registerActionFactory('foo', () => action);
 
 			return app.getAction('foo').then(() => {
-				isCombinedRegistry(registry);
+				assert.strictEqual(registry, app.registryProvider);
 			});
 		},
 
@@ -491,10 +483,10 @@ registerSuite({
 			});
 		},
 
-		'action.configure() is passed a combined registry'() {
-			let registry: CombinedRegistry = null;
+		'action.configure() is passed the registryProvider'() {
+			let registry: RegistryProvider = null;
 			const action = createAction();
-			action.configure = (actual: CombinedRegistry) => { registry = actual; };
+			action.configure = (actual: RegistryProvider) => { registry = actual; };
 
 			const app = createApp();
 			app.loadDefinition({
@@ -507,7 +499,7 @@ registerSuite({
 			});
 
 			return app.getAction('foo').then(() => {
-				isCombinedRegistry(registry);
+				assert.strictEqual(registry, app.registryProvider);
 			});
 		},
 
@@ -595,21 +587,19 @@ registerSuite({
 				return rejects(app.getAction('foo'), Error);
 			},
 
-			'passes the resolved store to the action factory'() {
-				const action = createAction();
-				let received: StoreLike = null;
-
-				const store = createStore();
+			'factory is passed a store reference in its stateFrom option'() {
+				const expected = createStore();
+				let actual: StoreLike = null;
 
 				const app = createApp();
-				app.registerStore('store', store);
+				app.registerStore('store', expected);
 				app.loadDefinition({
 					actions: [
 						{
 							id: 'foo',
-							factory(_: any, store: StoreLike) {
-								received = store;
-								return action;
+							factory(options) {
+								actual = options.stateFrom;
+								return createAction();
 							},
 							stateFrom: 'store'
 						}
@@ -617,58 +607,54 @@ registerSuite({
 				});
 
 				return app.getAction('foo').then(() => {
-					assert.strictEqual(received, store);
+					assert.strictEqual(actual, expected);
 				});
 			},
 
 			'stateFrom may be an actual store, rather than a store identifier'() {
-				const action = createAction();
-				let received: StoreLike = null;
-
-				const store = createStore();
+				const expected = createStore();
+				let actual: StoreLike = null;
 
 				const app = createApp();
 				app.loadDefinition({
 					actions: [
 						{
 							id: 'foo',
-							factory(_: any, store: StoreLike) {
-								received = store;
-								return action;
+							factory(options) {
+								actual = options.stateFrom;
+								return createAction();
 							},
-							stateFrom: store
+							stateFrom: expected
 						}
 					]
 				});
 
 				return app.getAction('foo').then(() => {
-					assert.strictEqual(received, store);
+					assert.strictEqual(actual, expected);
 				});
 			},
 
 			'overrides the default action store'() {
-				const action = createAction();
-				let received: StoreLike = null;
+				const expected = createStore();
+				let actual: StoreLike = null;
 
 				const defaultActionStore = createStore();
 				const app = createApp({ defaultActionStore });
-
-				const store = createStore();
 				app.loadDefinition({
 					actions: [
 						{
 							id: 'foo',
-							factory(_: any, store: StoreLike) {
-								received = store;
-								return action;
+							factory(options) {
+								actual = options.stateFrom;
+								return createAction();
 							},
-							stateFrom: store
+							stateFrom: expected
 						}
 					]
 				});
 
 				return app.getAction('foo').then(() => {
-					assert.strictEqual(received, store);
+					assert.strictEqual(actual, expected);
 				});
 			}
 		},
@@ -961,13 +947,11 @@ registerSuite({
 				}
 			},
 
-			'factory is passed a combined registry'() {
-				let registries: { foo: CombinedRegistry, bar: CombinedRegistry } = {
-					foo: null,
-					bar: null
-				};
-				stubActionFactory((registry: CombinedRegistry) => {
-					registries.bar = registry;
+			'factory is always passed registryProvider options'() {
+				let fooOptions: ActionFactoryOptions = null;
+				let barOptions: ActionFactoryOptions = null;
+				stubActionFactory((options) => {
+					barOptions = options;
 					return createAction();
 				});
 
@@ -976,8 +960,8 @@ registerSuite({
 					actions: [
 						{
 							id: 'foo',
-							factory(registry) {
-								registries.foo = registry;
+							factory(options) {
+								fooOptions = options;
 								return createAction();
 							}
 						},
@@ -992,8 +976,8 @@ registerSuite({
 					app.getAction('foo'),
 					app.getAction('bar')
 				]).then(() => {
-					isCombinedRegistry(registries.foo);
-					isCombinedRegistry(registries.bar);
+					assert.strictEqual(fooOptions.registryProvider, app.registryProvider);
+					assert.strictEqual(barOptions.registryProvider, app.registryProvider);
 				});
 			},
 
@@ -1008,8 +992,8 @@ registerSuite({
 					actions: [
 						{
 							id: 'foo',
-							factory(_: any, store: StoreLike) {
-								received = store;
+							factory(options) {
+								received = options.stateFrom;
 								return action;
 							}
 						}

--- a/tests/unit/createApp/customElements.ts
+++ b/tests/unit/createApp/customElements.ts
@@ -2,7 +2,7 @@ import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
-import createApp from 'src/createApp';
+import createApp, { WidgetFactoryOptions } from 'src/createApp';
 
 import { stub as stubWidgetFactory } from '../../fixtures/widget-factory';
 import {
@@ -32,7 +32,7 @@ registerSuite({
 			});
 
 			const wrapper = app.getCustomElementFactory('foo-bar');
-			const expectedOptions = {};
+			const expectedOptions = <WidgetFactoryOptions> {};
 			const receivedReturnValue = wrapper(expectedOptions);
 			assert.strictEqual(receivedOptions, expectedOptions);
 			assert.strictEqual(receivedReturnValue, expectedReturnValue);

--- a/tests/unit/createApp/realize.ts
+++ b/tests/unit/createApp/realize.ts
@@ -342,6 +342,12 @@ registerSuite({
 			});
 		},
 
+		'the "id" option must not be present in data-options'() {
+			app.registerCustomElementFactory('foo-bar', createWidget);
+			projector.innerHTML = `<foo-bar data-options="${opts({ id: {} })}"></foo-bar>`;
+			return rejects(app.realize(root), Error, 'Unexpected id value in data-options (in "{\\"id\\":{}}")');
+		},
+
 		'the "registryProvider" option must not be present in data-options'() {
 			app.registerCustomElementFactory('foo-bar', createWidget);
 			projector.innerHTML = `<foo-bar data-options="${opts({ registryProvider: {} })}"></foo-bar>`;
@@ -361,138 +367,68 @@ registerSuite({
 			});
 		},
 
-		'if present, the "stateFrom" option': {
-			'must be a string'() {
-				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 5 })}"></foo-bar>`;
-				return rejects(app.realize(root), TypeError, 'Expected stateFrom value in data-options to be a non-empty string (in "{\\"stateFrom\\":5}")');
-			},
-
-			'must be a non-empty string'() {
-				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: '' })}"></foo-bar>`;
-				return rejects(app.realize(root), TypeError, 'Expected stateFrom value in data-options to be a non-empty string (in "{\\"stateFrom\\":\\"\\"}")');
-			},
-
-			'must identify a registered store'() {
-				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
-				return rejects(app.realize(root), Error);
-			},
-
-			'causes the custom element factory to be called with a stateFrom option set to the store'() {
-				let actual: { stateFrom: StoreLike } = null;
-				app.registerCustomElementFactory('foo-bar', (options) => {
-					actual = <any> options;
-					return createActualWidget({ tagName: 'mark' });
-				});
-				const expected = createStore();
-				app.registerStore('store', expected);
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
-				return app.realize(root).then(() => {
-					assert.isOk(actual);
-					assert.strictEqual(actual.stateFrom, expected);
-				});
-			},
-
-			'takes precedence over data-state-from'() {
-				let actual: { stateFrom: StoreLike } = null;
-				app.registerCustomElementFactory('foo-bar', (options) => {
-					actual = <any> options;
-					return createActualWidget({ tagName: 'mark' });
-				});
-				const expected = createStore();
-				app.registerStore('store', expected);
-				app.registerStore('otherStore', createStore());
-				projector.innerHTML = `<foo-bar data-state-from="otherStore" data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
-				return app.realize(root).then(() => {
-					assert.isOk(actual);
-					assert.strictEqual(actual.stateFrom, expected);
-				});
-			},
-
-			'takes precedence over <app-projector data-state-from>'() {
-				let actual: { stateFrom: StoreLike } = null;
-				app.registerCustomElementFactory('foo-bar', (options) => {
-					actual = <any> options;
-					return createActualWidget({ tagName: 'mark' });
-				});
-				const expected = createStore();
-				app.registerStore('store', expected);
-				app.registerStore('otherStore', createStore());
-				projector.setAttribute('data-state-from', 'otherStore');
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
-				return app.realize(root).then(() => {
-					assert.isOk(actual);
-					assert.strictEqual(actual.stateFrom, expected);
-				});
-			},
-
-			'takes precedence over the default widget store'() {
-				const app = createApp({ defaultWidgetStore: createStore() });
-				let actual: { stateFrom: StoreLike } = null;
-				app.registerCustomElementFactory('foo-bar', (options) => {
-					actual = <any> options;
-					return createActualWidget({ tagName: 'mark' });
-				});
-				const expected = createStore();
-				app.registerStore('store', expected);
-				projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: 'store' })}"></foo-bar>`;
-				return app.realize(root).then(() => {
-					assert.isOk(actual);
-					assert.strictEqual(actual.stateFrom, expected);
-				});
-			}
+		'the "state" option must not be present in data-options'() {
+			app.registerCustomElementFactory('foo-bar', createWidget);
+			projector.innerHTML = `<foo-bar data-options="${opts({ state: {} })}"></foo-bar>`;
+			return rejects(app.realize(root), Error, 'Unexpected state value in data-options (in "{\\"state\\":{}}")');
 		},
 
-		'if present, the "listeners" option': {
-			'must be an object (not null)'() {
+		'the "stateFrom" option must not be present in data-options'() {
+			app.registerCustomElementFactory('foo-bar', createWidget);
+			projector.innerHTML = `<foo-bar data-options="${opts({ stateFrom: {} })}"></foo-bar>`;
+			return rejects(app.realize(root), Error, 'Unexpected stateFrom value in data-options (in "{\\"stateFrom\\":{}}")');
+		},
+
+		'the "listeners" option must not be present in data-options'() {
+			app.registerCustomElementFactory('foo-bar', createWidget);
+			projector.innerHTML = `<foo-bar data-options="${opts({ listeners: {} })}"></foo-bar>`;
+			return rejects(app.realize(root), Error, 'Unexpected listeners value in data-options (in "{\\"listeners\\":{}}")');
+		},
+
+		'the "listeners" option is derived from the data-listeners attribute': {
+			'realization fails if the data-listeners value is not valid JSON'() {
 				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({ listeners: null })}"></foo-bar>`;
-				return rejects(
-					app.realize(root),
-					TypeError,
-					'Expected listeners value in data-options to be a widget listeners map with action identifiers (in "{\\"listeners\\":null}")'
-				).then(() => {
-					projector.innerHTML = `<foo-bar data-options="${opts({ listeners: 42 })}"></foo-bar>`;
-					return rejects(
-						app.realize(root),
-						TypeError,
-						'Expected listeners value in data-options to be a widget listeners map with action identifiers (in "{\\"listeners\\":42}")');
+				projector.innerHTML = `<foo-bar data-listeners="${opts({}).slice(1)}"></foo-bar>`;
+				return rejects(app.realize(root), SyntaxError).then((err) => {
+					assert.match(err.message, /^Invalid data-listeners:/);
+					assert.match(err.message, / \(in "}"\)$/);
+				});
+			},
+
+			'realization fails if the data-listeners value does not encode an object'() {
+				app.registerCustomElementFactory('foo-bar', createWidget);
+				projector.innerHTML = `<foo-bar data-listeners="${opts(null)}"></foo-bar>`;
+				return rejects(app.realize(root), TypeError, 'Expected object from data-listeners (in "null")').then(() => {
+					projector.innerHTML = `<foo-bar data-listeners="${opts(42)}"></foo-bar>`;
+					return rejects(app.realize(root), TypeError, 'Expected object from data-listeners (in "42")');
 				});
 			},
 
 			'property values must be strings or arrays of strings'() {
 				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({
-					listeners: {
-						type: 5
-					}
+				projector.innerHTML = `<foo-bar data-listeners="${opts({
+					type: 5
 				})}"></foo-bar>`;
 				return rejects(
 					app.realize(root),
 					TypeError,
-					'Expected listeners value in data-options to be a widget listeners map with action identifiers (in "{\\"listeners\\":{\\"type\\":5}}")'
+					'Expected data-listeners to be a widget listeners map with action identifiers (in "{\\"type\\":5}")'
 				).then(() => {
-					projector.innerHTML = `<foo-bar data-options="${opts({
-						listeners: {
-							type: [true]
-						}
+					projector.innerHTML = `<foo-bar data-listeners="${opts({
+						type: [true]
 					})}"></foo-bar>`;
 					return rejects(
 						app.realize(root),
 						TypeError,
-						'Expected listeners value in data-options to be a widget listeners map with action identifiers (in "{\\"listeners\\":{\\"type\\":[true]}}")'
+						'Expected data-listeners to be a widget listeners map with action identifiers (in "{\\"type\\":[true]}")'
 					);
 				});
 			},
 
 			'the strings must identify registered actions'() {
 				app.registerCustomElementFactory('foo-bar', createWidget);
-				projector.innerHTML = `<foo-bar data-options="${opts({
-					listeners: {
-						type: 'action'
-					}
+				projector.innerHTML = `<foo-bar data-listeners="${opts({
+					type: 'action'
 				})}"></foo-bar>`;
 				return rejects(app.realize(root), Error);
 			},
@@ -505,11 +441,9 @@ registerSuite({
 				});
 				const expected = createAction();
 				app.registerAction('action', expected);
-				projector.innerHTML = `<foo-bar data-options="${opts({
-					listeners: {
-						string: 'action',
-						array: ['action']
-					}
+				projector.innerHTML = `<foo-bar data-listeners="${opts({
+					string: 'action',
+					array: ['action']
 				})}"></foo-bar>`;
 				return app.realize(root).then(() => {
 					assert.isNotNull(actual);
@@ -819,15 +753,6 @@ registerSuite({
 	},
 
 	'identifying and retrieving widgets': {
-		'via data-options'() {
-			const fooBar = createActualWidget();
-			app.registerCustomElementFactory('foo-bar', () => fooBar);
-			projector.innerHTML = '<foo-bar data-options="{&quot;id&quot;:&quot;fooBar&quot;}"></foo-bar>';
-			return app.realize(root).then(() => {
-				assert.equal(app.identifyWidget(fooBar), 'fooBar');
-			});
-		},
-
 		'via data-uid'() {
 			const fooBar = createActualWidget();
 			app.registerCustomElementFactory('foo-bar', () => fooBar);
@@ -846,17 +771,11 @@ registerSuite({
 			});
 		},
 
-		'data-options takes precedence over data-uid over id'() {
-			const fooBar = createActualWidget();
-			app.registerCustomElementFactory('foo-bar', () => fooBar);
+		'data-uid takes precedence over id'() {
 			const bazQux = createActualWidget();
 			app.registerCustomElementFactory('baz-qux', () => bazQux);
-			projector.innerHTML = `
-				<foo-bar data-uid="bazQux" data-options="{&quot;id&quot;:&quot;fooBar&quot;}"></foo-bar>
-				<baz-qux id="fooBar" data-uid="bazQux"></baz-qux>
-			`;
+			projector.innerHTML = '<baz-qux id="fooBar" data-uid="bazQux"></baz-qux>';
 			return app.realize(root).then(() => {
-				assert.equal(app.identifyWidget(fooBar), 'fooBar');
 				assert.equal(app.identifyWidget(bazQux), 'bazQux');
 			});
 		},

--- a/tests/unit/createApp/realize.ts
+++ b/tests/unit/createApp/realize.ts
@@ -65,7 +65,7 @@ registerSuite({
 
 	'tag name comparisons are case-insensitive'() {
 		app.registerWidget('foo', createActualWidget({ tagName: 'mark' }));
-		projector.innerHTML = '<app-widget id="foo"></app-widget>';
+		projector.innerHTML = '<aPp-WiDgEt id="foo"></aPp-WiDgEt>';
 		return app.realize(root).then(() => {
 			assert.equal(projector.firstChild.nodeName, 'MARK');
 		});
@@ -81,7 +81,7 @@ registerSuite({
 
 	'`is` attribute comparison is case-insensitive'() {
 		app.registerWidget('foo', createActualWidget({ tagName: 'mark' }));
-		projector.innerHTML = '<div is="app-widget" id="foo"></div>';
+		projector.innerHTML = '<div is="aPp-WiDgEt" id="foo"></div>';
 		return app.realize(root).then(() => {
 			assert.equal(projector.firstChild.nodeName, 'MARK');
 		});

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -1069,73 +1069,129 @@ registerSuite({
 					return app.getWidget('foo').then(() => {
 						assert.strictEqual(actual, expected);
 					});
+				}
+			},
+
+			'with state option': {
+				'state is added to the defined store before factory is called'() {
+					let calls: string[] = [];
+					let addArgs: any[][] = [];
+
+					const store = createStore();
+					(<any> store).add = (...args: any[]) => {
+						calls.push('add');
+						addArgs.push(args);
+						return Promise.resolve();
+					};
+
+					const state = { foo: 'bar' };
+
+					const app = createApp();
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								factory() {
+									calls.push('factory');
+									return createWidget();
+								},
+								state,
+								stateFrom: store
+							}
+						]
+					});
+
+					return app.getWidget('foo').then(() => {
+						assert.deepEqual(calls, ['add', 'factory']);
+						assert.deepEqual(addArgs, [[{ foo: 'bar' }, { id: 'foo' }]]);
+					});
 				},
 
-				'and state option': {
-					'state is added to the store before factory is called'() {
-						let calls: string[] = [];
-						let addArgs: any[][] = [];
+				'state is added to the default store before factory is called'() {
+					let calls: string[] = [];
+					let addArgs: any[][] = [];
 
-						const store = createStore();
-						(<any> store).add = (...args: any[]) => {
-							calls.push('add');
-							addArgs.push(args);
-							return Promise.resolve();
-						};
+					const store = createStore();
+					(<any> store).add = (...args: any[]) => {
+						calls.push('add');
+						addArgs.push(args);
+						return Promise.resolve();
+					};
 
-						const state = { foo: 'bar' };
+					const state = { foo: 'bar' };
 
-						const app = createApp();
-						app.loadDefinition({
-							widgets: [
-								{
-									id: 'foo',
-									factory() {
-										calls.push('factory');
-										return createWidget();
-									},
-									state,
-									stateFrom: store
-								}
-							]
-						});
+					const app = createApp();
+					app.defaultWidgetStore = store;
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								factory() {
+									calls.push('factory');
+									return createWidget();
+								},
+								state
+							}
+						]
+					});
 
-						return app.getWidget('foo').then(() => {
-							assert.deepEqual(calls, ['add', 'factory']);
-							assert.deepEqual(addArgs, [[{ foo: 'bar' }, { id: 'foo' }]]);
-						});
-					},
+					return app.getWidget('foo').then(() => {
+						assert.deepEqual(calls, ['add', 'factory']);
+						assert.deepEqual(addArgs, [[{ foo: 'bar' }, { id: 'foo' }]]);
+					});
+				},
 
-					'the factory is called even if adding state fails'() {
-						let calls: string[] = [];
+				'the factory is called even if adding state fails'() {
+					let calls: string[] = [];
 
-						const store = createStore();
-						(<any> store).add = (...args: any[]) => {
-							calls.push('add');
-							return Promise.reject(new Error());
-						};
+					const store = createStore();
+					(<any> store).add = (...args: any[]) => {
+						calls.push('add');
+						return Promise.reject(new Error());
+					};
 
-						const state = { foo: 'bar' };
+					const state = { foo: 'bar' };
 
-						const app = createApp();
-						app.loadDefinition({
-							widgets: [
-								{
-									id: 'foo',
-									factory() {
-										calls.push('factory');
-										return createWidget();
-									},
-									state,
-									stateFrom: store
-								}
-							]
-						});
+					const app = createApp();
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								factory() {
+									calls.push('factory');
+									return createWidget();
+								},
+								state,
+								stateFrom: store
+							}
+						]
+					});
 
-						return app.getWidget('foo').then(() => {
-							assert.deepEqual(calls, ['add', 'factory']);
-						});
-					}
+					return app.getWidget('foo').then(() => {
+						assert.deepEqual(calls, ['add', 'factory']);
+					});
+				},
+
+				'the factory is called even if there is no store to add state to'() {
+					let calls: string[] = [];
+
+					const app = createApp();
+					app.loadDefinition({
+						widgets: [
+							{
+								id: 'foo',
+								factory() {
+									calls.push('factory');
+									return createWidget();
+								},
+								state: { foo: 'bar' }
+							}
+						]
+					});
+
+					return app.getWidget('foo').then(() => {
+						assert.deepEqual(calls, ['factory']);
+					});
 				}
 			}
 		},


### PR DESCRIPTION
Includes most of the refactoring from #39.

Now allows initial state to be defined in action definitions. Reverts #21 for consistency. Action factories now receive a single options object, with a `RegistryProvider` instead of a `CombinedRegistry`. The `RegistryProvider` is also used when configuring actions. Certain properties are no longer allowed in custom element `data-options`.

