### PR TITLE
Create custom widgets with correct stateFrom store

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "codecov.io": "0.1.6",
     "dojo-loader": ">=2.0.0-beta.7",
+    "dojo-stores": "^2.0.0-alpha.1",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -514,7 +514,7 @@ function addIdentifier(app: App, id: Identifier) {
 
 function createCustomWidget(app: App, id: string) {
 	const customFactories = customElementFactories.get(app);
-	const { registryProvider, defaultActionStore: stateFrom } = app;
+	const { registryProvider, defaultWidgetStore: stateFrom } = app;
 
 	return app.defaultWidgetStore.get(id).then((state: any) => {
 		const options: any = { id, stateFrom, registryProvider, state };

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -59,9 +59,11 @@ export const loaderOptions = {
 		{ name: 'dojo-dom', location: 'node_modules/dojo-dom' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: 'dojo-stores', location: 'node_modules/dojo-stores' },
 		{ name: 'dojo-widgets', location: 'node_modules/dojo-widgets' },
 		{ name: 'maquette', location: 'node_modules/maquette/dist', main: 'maquette' },
-		{ name: 'immutable', location: 'node_modules/immutable/dist', main: 'immutable' }
+		{ name: 'immutable', location: 'node_modules/immutable/dist', main: 'immutable' },
+		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
 	]
 };
 

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -1,5 +1,7 @@
 import { EventedListener, EventedListenersMap } from 'dojo-compose/mixins/createEvented';
+import createMemoryStore from 'dojo-stores/createMemoryStore';
 import Promise from 'dojo-shim/Promise';
+import createActualWidget, { Widget as ActualWidget } from 'dojo-widgets/createWidget';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
@@ -65,6 +67,22 @@ registerSuite({
 			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
 				return app.getWidget('foo').then((widget) => {
 					assert.isObject(widget);
+				});
+			});
+		},
+
+		'widget created for custom type observes state'() {
+			const defaultWidgetStore = createMemoryStore();
+			const app = createApp({ defaultWidgetStore });
+
+			app.registerCustomElementFactory('custom-element', createActualWidget);
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element', value: 1}).then(() => {
+				return app.getWidget('foo').then((widget: ActualWidget<any>) => {
+					assert.equal(widget.state.value, 1);
+					return defaultWidgetStore.patch({id: 'foo', value: 2}).then(() => {
+						assert.equal(widget.state.value, 2);
+					});
 				});
 			});
 		},


### PR DESCRIPTION
The wrong store was passed as the `stateFrom` option. First commit contains a failing test, second commit fixes.