### PR TITLE
Assorted typing changes

### DIFF
--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -47,6 +47,14 @@ function isInstance(value: any): value is Instance {
 	return value && typeof value === 'object';
 }
 
+// Used as a cast for definitions passed to resolveFactory(). The definitions need to be cast because
+// CustomElementDefinition does not have an `instance` property. Note that at this point the definition has already
+// been validated to ensure it has either a factory or an instance.
+interface DestructurableDefinition {
+	instance?: Instance | string;
+	factory?: Factory | string;
+}
+
 /**
  * Resolve a factory for an action, custom element, store or widget.
  *
@@ -65,8 +73,7 @@ function resolveFactory(type: 'store', definition: StoreDefinition, resolveMid: 
 function resolveFactory(type: 'widget', definition: WidgetDefinition, resolveMid: ResolveMid): Promise<WidgetFactory>;
 function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition | ItemDefinition<Factory, Instance>, resolveMid: ResolveMid): Promise<Factory>;
 function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition | ItemDefinition<Factory, Instance>, resolveMid: ResolveMid): Promise<Factory> {
-	const { factory } = definition;
-	const { instance = null } = (<ItemDefinition<Factory, Instance>> definition);
+	const { factory, instance } = <DestructurableDefinition> definition;
 
 	if (typeof factory === 'function') {
 		return Promise.resolve(factory);

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -98,6 +98,7 @@ function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition 
 					.catch(reject);
 			}
 			else {
+				// Calling code ensures that factory at this point is a string, even though TypeScript can't infer that.
 				resolveMid<Factory>(<string> factory)
 					.then((defaultExport) => {
 						if (typeof defaultExport !== 'function') {

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -79,9 +79,8 @@ function resolveFactory(type: FactoryTypes, definition: CustomElementDefinition 
 		return Promise.resolve(factory);
 	}
 	else if (isInstance(instance)) {
-		// <any> hammer since TypeScript can't resolve match the correct overloaded Instance type with the correct
-		// Factory return value.
-		const factory: Factory = () => <any> instance;
+		// Cast to Factory since TypeScript gets confused with the overloaded Factory types that can return promises.
+		const factory = (() => instance) as Factory;
 		return Promise.resolve(factory);
 	}
 	else {


### PR DESCRIPTION
Please see commits. Some are sensible enough, others are to work around linting errors in `atom-typescript`. That's not great but doesn't hurt either I think.