### PR TITLE
Register factories custom elements to avoid duplicate creation calls

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -569,17 +569,20 @@ function addIdentifier(app: App, id: Identifier) {
 
 function createCustomWidget(app: App, id: string) {
 	const { registryProvider, defaultWidgetStore } = app;
+	let factoryHandle: Handle;
 	// istanbul ignore if
 	if (!defaultWidgetStore) {
 		throw new Error('A default widget store must be configured in order to create custom widgets');
 	}
 
 	return defaultWidgetStore.get(id).then((state: any) => {
-		const options: WidgetFactoryOptions = { id, stateFrom: defaultWidgetStore, registryProvider, state };
 		const customFactory = customElementFactories.get(app).get(state.type);
-		return customFactory(options);
+		factoryHandle = app.registerWidgetFactory(id, customFactory);
+		const factory = widgetFactories.get(app).get(id);
+
+		return factory();
 	}).then((widget) => {
-		widget.own(registerInstance(app, widget, id));
+		widget.own(factoryHandle);
 		return widget;
 	});
 }

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -577,8 +577,15 @@ function createCustomWidget(app: App, id: string) {
 
 	return defaultWidgetStore.get(id).then((state: any) => {
 		const customFactory = customElementFactories.get(app).get(state.type);
-		factoryHandle = app.registerWidgetFactory(id, customFactory);
-		const factory = widgetFactories.get(app).get(id);
+		const factories = widgetFactories.get(app);
+		let factory: RegisteredFactory<WidgetLike>;
+		try {
+			// add final check before attempting to register the factory
+			factory = factories.get(id);
+		} catch (err) {
+			factoryHandle = app.registerWidgetFactory(id, customFactory);
+			factory = factories.get(id);
+		}
 
 		return factory();
 	}).then((widget) => {

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -576,19 +576,15 @@ function createCustomWidget(app: App, id: string) {
 	}
 
 	return defaultWidgetStore.get(id).then((state: any) => {
-		const customFactory = customElementFactories.get(app).get(state.type);
-		const factories = widgetFactories.get(app);
-		let factory: RegisteredFactory<WidgetLike>;
-		try {
-			// add final check before attempting to register the factory
-			factory = factories.get(id);
-		}
-		catch (err) {
+		const hasRegisteredFactory = widgetFactories.get(app).has(id);
+		const hasRegisteredInstance = widgetInstances.get(app).has(id);
+
+		if (!hasRegisteredFactory && !hasRegisteredInstance) {
+			const customFactory = customElementFactories.get(app).get(state.type);
 			factoryHandle = app.registerWidgetFactory(id, customFactory);
-			factory = factories.get(id);
 		}
 
-		return factory();
+		return app.getWidget(id);
 	}).then((widget) => {
 		widget.own(factoryHandle);
 		return widget;

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -582,7 +582,8 @@ function createCustomWidget(app: App, id: string) {
 		try {
 			// add final check before attempting to register the factory
 			factory = factories.get(id);
-		} catch (err) {
+		}
+		catch (err) {
 			factoryHandle = app.registerWidgetFactory(id, customFactory);
 			factory = factories.get(id);
 		}

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -72,6 +72,23 @@ registerSuite({
 			});
 		},
 
+		'multiple calls to getWidget for the same id, do not result in duplicate widgets being created'() {
+			const defaultWidgetStore = createSpyStore();
+			const app = createApp({ defaultWidgetStore });
+
+			app.registerCustomElementFactory('custom-element', createAsyncSpyWidget);
+
+			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
+				const promise1 = app.getWidget('foo');
+				const promise2 = app.getWidget('foo');
+
+				return Promise.all([promise1, promise2]);
+			})
+			.then(([widget1, widget2]) => {
+				assert.equal(widget1, widget2);
+			});
+		},
+
 		'widget created for custom type observes state'() {
 			const defaultWidgetStore = createMemoryStore();
 			const app = createApp({ defaultWidgetStore });


### PR DESCRIPTION
**Type:** bug

**Description:** 

Register factories for dynamically created custom factories so that if the same widget is requested during creation a promise is returned instead of attempting to create the widget twice.

**Related Issue:** #80 

fixes #80

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [x] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] The code passes the CI tests
* [x] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged