### PR TITLE
Avoid debugger pauses when getting widgets

### DIFF
--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -1009,7 +1009,7 @@ const createApp = compose({
 			const instances = widgetInstances.get(this);
 
 			let missingFactory: any;
-			return new Promise((resolve, reject) => {
+			return new Promise((resolve) => {
 				let factory: WidgetFactory;
 				try {
 					factory = factories.get(id);
@@ -1018,7 +1018,7 @@ const createApp = compose({
 				}
 				catch (err) {
 					missingFactory = err;
-					reject();
+					resolve(Promise.reject(err));
 					return;
 				}
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -1025,11 +1025,11 @@ const createApp = compose({
 				// Be sure to call the factory synchronously.
 				resolve(factory());
 			}).catch((err) => {
-				if (missingFactory) {
+				if (missingFactory && instances.has(id)) {
 					return instances.get(id);
 				}
 				else {
-					throw err;
+					return Promise.reject(err);
 				}
 			}).catch((err) => {
 				if (missingFactory && this.defaultWidgetStore) {
@@ -1037,10 +1037,10 @@ const createApp = compose({
 					return createCustomWidget(this, id);
 				}
 				else {
-					throw err;
+					return Promise.reject(err);
 				}
 			}).catch((err) => {
-				throw missingFactory || err;
+				return Promise.reject(missingFactory || err);
 			});
 		},
 


### PR DESCRIPTION
Fixes #85.

The workarounds seem pretty bizarre. I suspect both Chrome and Firefox have heuristics for detecting Promise patterns, but they seem to pause unnecessarily. They may behave better once we can use native promises (https://github.com/dojo/shim/issues/21).