### PR TITLE
Proof of Concept: "Scene" management

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,18 @@
 module.exports = function (grunt) {
 	require('grunt-dojo2').initConfig(grunt, {
 		/* any custom configuration goes here */
+		copy: {
+			staticExampleFiles: {
+				expand: true,
+				cwd: '.',
+				src: ['examples/**/*.html'],
+				dest: '<%= devDirectory %>'
+			}
+		},
 	});
+
+	// Re-register the dev task so it includes copy:staticExampleFiles
+	const devTasks = grunt.config.get('devTasks');
+	devTasks.push('copy:staticExampleFiles');
+	grunt.registerTask('dev', devTasks);
 };

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Scene Diffs</title>
+</head>
+<body>
+	<!-- Loading the dojo-loader (minified) -->
+	<script src="../../node_modules/dojo-loader/loader.min.js"></script>
+	<!-- Loading the rest of the environment -->
+	<script src="./index.js"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,8 +8,5 @@
 	<script src="../../node_modules/dojo-loader/loader.min.js"></script>
 	<!-- Loading the rest of the environment -->
 	<script src="./index.js"></script>
-	<app-projector>
-		<app-widget id="foo"></app-widget>
-	</app-projector>
 </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -8,5 +8,8 @@
 	<script src="../../node_modules/dojo-loader/loader.min.js"></script>
 	<!-- Loading the rest of the environment -->
 	<script src="./index.js"></script>
+	<app-projector>
+		<app-widget id="foo"></app-widget>
+	</app-projector>
 </body>
 </html>

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -1,0 +1,27 @@
+(<DojoLoader.RootRequire> require).config({
+	baseUrl: '../..',
+	packages: [
+		{ name: 'examples', location: '_build/examples' },
+		{ name: 'src', location: '_build/src' },
+		{ name: 'dojo-app', location: 'node_modules/dojo-app' },
+		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
+		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
+		{ name: 'dojo-dom', location: 'node_modules/dojo-dom' },
+		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+		{ name: 'dojo-stores', location: 'node_modules/dojo-stores' },
+		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+		{ name: 'dojo-widgets', location: 'node_modules/dojo-widgets' },
+		{ name: 'immutable', location: 'node_modules/immutable/dist' },
+		{ name: 'maquette', location: 'node_modules/maquette/dist' },
+		{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
+	],
+	map: {
+		'*': {
+			'maquette': 'maquette/maquette.min',
+			'immutable': 'immutable/immutable.min'
+		}
+	}
+});
+
+/* Requiring in the main module */
+require(['examples/main'], function () {});

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,0 +1,9 @@
+import createWidget from 'dojo-widgets/createWidget';
+
+import createApp from '../src/createApp';
+
+const app = createApp();
+
+app.registerWidget('foo', createWidget({ state: { label: 'foo' }, tagName: 'h1' }));
+
+app.realize(document.body);

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -7,6 +7,7 @@ const app = createApp();
 
 app.registerWidget('foo', createWidget({ state: { label: 'foo' }, tagName: 'h1' }));
 app.registerWidget('bar', createWidget({ state: { label: 'bar' }, tagName: 'h1' }));
+app.registerWidget('baz', createWidget({ state: { label: 'baz' }, tagName: 'h1' }));
 
 global.renderFoo = () => {
 	app.renderScene({
@@ -14,7 +15,24 @@ global.renderFoo = () => {
 		root: document.body,
 		nodes: [
 			{
-				widget: 'foo'
+				tagName: 'ul',
+				children: [
+					{
+						tagName: 'li',
+						children: [
+							{
+								widget: 'foo'
+							}
+						]
+					},
+					{
+						tagName: 'li',
+						children: [ '⬆️ should be foo' ]
+					}
+				]
+			},
+			{
+				widget: 'baz'
 			}
 		]
 	});
@@ -25,7 +43,24 @@ global.renderBar = () => {
 		root: document.body,
 		nodes: [
 			{
-				widget: 'bar'
+				tagName: 'ol',
+				children: [
+					{
+						tagName: 'li',
+						children: [
+							{
+								widget: 'bar'
+							}
+						]
+					},
+					{
+						tagName: 'li',
+						children: [ '⬆️ should be bar' ]
+					}
+				]
+			},
+			{
+				widget: 'baz'
 			}
 		]
 	});

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -6,4 +6,15 @@ const app = createApp();
 
 app.registerWidget('foo', createWidget({ state: { label: 'foo' }, tagName: 'h1' }));
 
-app.realize(document.body);
+app.renderScene({
+	// FIXME: App must be created with the root element, disallow it from changing between scenes.
+	root: document.body,
+	tree: {
+		projector: true,
+		append: [
+			{
+				widget: 'foo'
+			}
+		]
+	}
+});

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,13 +1,49 @@
 import global from 'dojo-core/global';
+import createMemoryStore from 'dojo-stores/createMemoryStore';
 import createWidget from 'dojo-widgets/createWidget';
 
 import createApp from '../src/createApp';
 
-const app = createApp();
+const defaultWidgetStore = createMemoryStore();
+const app = createApp({ defaultWidgetStore });
 
-app.registerWidget('foo', createWidget({ state: { label: 'foo' }, tagName: 'h1' }));
-app.registerWidget('bar', createWidget({ state: { label: 'bar' }, tagName: 'h1' }));
-app.registerWidget('baz', createWidget({ state: { label: 'baz' }, tagName: 'h1' }));
+// Widgets are destroyed when unrendered, but the app caches the factory result.
+// Prevent destruction for now.
+const createIndestructible = createWidget.extend({
+	destroy() {}
+});
+
+app.loadDefinition({
+	widgets: [
+		{
+			id: 'foo',
+			factory: createIndestructible,
+			options: { tagName: 'strong' },
+			state: { label: 'foo' }
+		},
+		{
+			id: 'bar',
+			factory: createIndestructible,
+			options: { tagName: 'em' },
+			state: { label: 'bar' }
+		},
+		{
+			id: 'baz',
+			factory: createIndestructible,
+			options: { tagName: 'del' },
+			state: { label: 'baz' }
+		}
+	]
+});
+
+global.interval = setInterval(() => {
+	const str = new Date().toLocaleTimeString();
+	defaultWidgetStore.patch({ label: `foo @ ${str}` }, { id: 'foo' });
+	defaultWidgetStore.patch({ label: `bar @ ${str}` }, { id: 'bar' });
+	defaultWidgetStore.patch({ label: `baz @ ${str}` }, { id: 'baz' });
+}, 1000);
+
+global.app = app;
 
 global.renderFoo = () => {
 	app.renderScene({
@@ -61,6 +97,55 @@ global.renderBar = () => {
 			},
 			{
 				widget: 'baz'
+			}
+		]
+	});
+};
+
+global.renderAll = () => {
+	app.renderScene({
+		root: document.body,
+		nodes: [
+			{
+				tagName: 'ol',
+				children: [
+					{
+						tagName: 'li',
+						children: [
+							{
+								widget: 'foo'
+							}
+						]
+					},
+					{
+						tagName: 'li',
+						children: [ '⬆️ should be foo' ]
+					},
+					{
+						tagName: 'li',
+						children: [
+							{
+								widget: 'bar'
+							}
+						]
+					},
+					{
+						tagName: 'li',
+						children: [ '⬆️ should be bar' ]
+					},
+					{
+						tagName: 'li',
+						children: [
+							{
+								widget: 'baz'
+							}
+						]
+					},
+					{
+						tagName: 'li',
+						children: [ '⬆️ should be baz' ]
+					}
+				]
 			}
 		]
 	});

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,3 +1,4 @@
+import global from 'dojo-core/global';
 import createWidget from 'dojo-widgets/createWidget';
 
 import createApp from '../src/createApp';
@@ -5,16 +6,35 @@ import createApp from '../src/createApp';
 const app = createApp();
 
 app.registerWidget('foo', createWidget({ state: { label: 'foo' }, tagName: 'h1' }));
+app.registerWidget('bar', createWidget({ state: { label: 'bar' }, tagName: 'h1' }));
 
-app.renderScene({
-	// FIXME: App must be created with the root element, disallow it from changing between scenes.
-	root: document.body,
-	tree: {
-		projector: true,
-		append: [
-			{
-				widget: 'foo'
-			}
-		]
-	}
-});
+global.renderFoo = () => {
+	app.renderScene({
+		// FIXME: App must be created with the root element, disallow it from changing between scenes.
+		root: document.body,
+		tree: {
+			projector: true,
+			append: [
+				{
+					widget: 'foo'
+				}
+			]
+		}
+	});
+};
+
+global.renderBar = () => {
+	app.renderScene({
+		root: document.body,
+		tree: {
+			projector: true,
+			append: [
+				{
+					widget: 'bar'
+				}
+			]
+		}
+	});
+};
+
+global.renderFoo();

--- a/examples/main.ts
+++ b/examples/main.ts
@@ -12,28 +12,22 @@ global.renderFoo = () => {
 	app.renderScene({
 		// FIXME: App must be created with the root element, disallow it from changing between scenes.
 		root: document.body,
-		tree: {
-			projector: true,
-			append: [
-				{
-					widget: 'foo'
-				}
-			]
-		}
+		nodes: [
+			{
+				widget: 'foo'
+			}
+		]
 	});
 };
 
 global.renderBar = () => {
 	app.renderScene({
 		root: document.body,
-		tree: {
-			projector: true,
-			append: [
-				{
-					widget: 'bar'
-				}
-			]
-		}
+		nodes: [
+			{
+				widget: 'bar'
+			}
+		]
 	});
 };
 

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -26,7 +26,7 @@ import realizeCustomElements, {
 	normalizeName
 } from './lib/realizeCustomElements';
 import RegistryProvider from './lib/RegistryProvider';
-import { render as renderScene, SceneElement } from './lib/sceneManagement';
+import { render as renderScene, RootNodes } from './lib/sceneManagement';
 
 export { RegistryProvider, ToAbsMid };
 
@@ -269,7 +269,7 @@ export interface WidgetListenersMap {
 
 export interface SceneOptions {
 	root: Element;
-	nodes: SceneElement[];
+	nodes: RootNodes;
 }
 
 /**

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -26,6 +26,7 @@ import realizeCustomElements, {
 	normalizeName
 } from './lib/realizeCustomElements';
 import RegistryProvider from './lib/RegistryProvider';
+import { render as renderScene, SceneElement } from './lib/sceneManagement';
 
 export { RegistryProvider, ToAbsMid };
 
@@ -266,6 +267,11 @@ export interface WidgetListenersMap {
 	[eventType: string]: WidgetListenerOrArray;
 }
 
+export interface SceneOptions {
+	root: Element;
+	tree: SceneElement;
+}
+
 /**
  * Read-only interface to access actions, custom element factories, stores and widgets.
  *
@@ -492,6 +498,8 @@ export interface AppMixin {
 	 * @return A handle to deregister *all* actions, stores and widgets that were registered.
 	 */
 	loadDefinition(definitions: Definitions): Handle;
+
+	renderScene(options: SceneOptions): Promise<Handle>;
 
 	/**
 	 * Extract declarative definition custom elements in the root and render widgets.
@@ -902,6 +910,10 @@ const createApp = compose({
 				}
 			}
 		};
+	},
+
+	renderScene(this: App, { root, tree }: SceneOptions) {
+		return renderScene(this, root, tree);
 	},
 
 	realize(this: App, root: Element) {

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -269,7 +269,7 @@ export interface WidgetListenersMap {
 
 export interface SceneOptions {
 	root: Element;
-	tree: SceneElement;
+	nodes: SceneElement[];
 }
 
 /**
@@ -912,8 +912,8 @@ const createApp = compose({
 		};
 	},
 
-	renderScene(this: App, { root, tree }: SceneOptions) {
-		return renderScene(this, root, tree);
+	renderScene(this: App, { root, nodes }: SceneOptions) {
+		return renderScene(this, root, nodes);
 	},
 
 	realize(this: App, root: Element) {

--- a/src/lib/sceneManagement.ts
+++ b/src/lib/sceneManagement.ts
@@ -5,7 +5,8 @@ import Promise from 'dojo-shim/Promise';
 import WeakMap from 'dojo-shim/WeakMap';
 import createWidget from 'dojo-widgets/createWidget';
 import { createProjector, Projector } from 'dojo-widgets/projector';
-import { VNode } from 'maquette';
+import { List } from 'immutable';
+import { h, VNode } from 'maquette';
 
 import {
 	Identifier,
@@ -13,10 +14,24 @@ import {
 	WidgetLike
 } from '../createApp';
 
-export type SceneElement = SceneWidget;
+export type SceneNode = SceneElement | SceneText | SceneWidget;
+export type RootNodes = (SceneElement | SceneWidget)[];
+
+export interface SceneElement {
+	tagName: string;
+	children?: SceneNode[];
+}
+function isSceneElement(node: any): node is SceneElement {
+	return typeof node === 'object' && 'tagName' in node;
+}
+
+export type SceneText = string;
 
 export interface SceneWidget {
 	widget: Identifier;
+}
+function isSceneWidget(node: any): node is SceneWidget {
+	return typeof node === 'object' && 'widget' in node;
 }
 
 interface Key {
@@ -33,36 +48,53 @@ class Counter {
 	}
 
 	incr() {
-		return `${this.prefix}.${this.count++}`;
+		this.count++;
+	}
+
+	get key(): Key {
+		return { value: this.value };
 	}
 
 	level() {
-		return new Counter(`${this.prefix}.${this.count}`);
+		return new Counter(this.value);
+	}
+
+	get value() {
+		return `${this.prefix}.${this.count}`;
 	}
 }
 
-type RenderFunction = () => VNode;
+type FlatVNodeChildren = (string | VNode)[];
+
+interface WidgetInVNode {
+	index: number;
+	siblings: FlatVNodeChildren;
+	widget: WidgetLike;
+}
 
 interface RenderState {
 	childrenKeys: WeakMap<Key, Key[]>;
+	counter: Counter;
 	handles: WeakMap<Key, Handle>;
 	invalidate: () => void;
-	rootChildren: (VNode | RenderFunction)[];
+	rootVNodes: FlatVNodeChildren;
 	rootKey: Key;
 	rootProjector: Projector;
+	unrenderedWidgetsInVNodes: WidgetInVNode[];
+	vNodes: WeakMap<Key, VNode>;
 	widgetKeys: Map<Identifier, Key>;
 	widgets: WeakMap<Key, WidgetLike>;
 }
 
 const renderState = new WeakMap<ReadOnlyRegistry, RenderState>();
 
-export function render(registry: ReadOnlyRegistry, root: Element, nodes: SceneElement[]) {
+export function render(registry: ReadOnlyRegistry, root: Element, nodes: RootNodes) {
 	const state = renderState.get(registry) || initialize(root);
 	if (!renderState.has(registry)) {
 		renderState.set(registry, state);
 	}
 
-	return update(registry, state, new Counter(), nodes)
+	return update(registry, state, nodes)
 		.then(() => {
 			return {
 				destroy() {
@@ -79,29 +111,32 @@ export function render(registry: ReadOnlyRegistry, root: Element, nodes: SceneEl
 
 function initialize(root: Element) {
 	const rootProjector = createProjector({ autoAttach: true, root });
-	const rootKey = { value: 'root' };
+	const counter = new Counter();
+	const { key: rootKey } = counter;
 	const childrenKeys = new WeakMap<Key, Key[]>();
 	childrenKeys.set(rootKey, []);
 
 	const proxy = createWidget.extend({
 		getChildrenNodes() {
-			return state.rootChildren.map(function (nodeOrRender) {
-				if (typeof nodeOrRender === 'function') {
-					return nodeOrRender();
-				}
-				return nodeOrRender;
-			});
+			for (const { index, siblings, widget } of state.unrenderedWidgetsInVNodes) {
+				siblings[index] = widget.render();
+			}
+			state.unrenderedWidgetsInVNodes = [];
+			return state.rootVNodes;
 		}
 	})({ tagName: 'div' });
 	rootProjector.append(proxy);
 
-	const state = {
+	const state: RenderState = {
 		childrenKeys,
+		counter,
 		handles: new WeakMap<Key, Handle>(),
 		invalidate: proxy.invalidate.bind(proxy),
-		rootChildren: [],
+		rootVNodes: [],
 		rootKey,
 		rootProjector,
+		unrenderedWidgetsInVNodes: [],
+		vNodes: new WeakMap<Key, VNode>(),
 		widgetKeys: new Map<Identifier, Key>(),
 		widgets: new WeakMap<Key, WidgetLike>()
 	};
@@ -112,69 +147,160 @@ function initialize(root: Element) {
 function update(
 	registry: ReadOnlyRegistry,
 	state: RenderState,
-	counter: Counter,
-	nodes: SceneElement[]
+	nodes: RootNodes
 ): Promise<void> {
-	return updateWidgets(registry, state, state.rootKey, counter.level(), nodes)
-		.then((widgets) => {
-			state.rootChildren = widgets.map((widget) => {
-				return widget.render.bind(widget);
-			});
-
+	return updateNodes(registry, state, state.rootKey, state.counter.level(), nodes)
+		.then(({ currentWidgetKeys, newWidgetsInVNodes, vNodes: rootVNodes }) => {
+			state.rootVNodes = rootVNodes;
+			state.unrenderedWidgetsInVNodes = newWidgetsInVNodes;
 			state.invalidate();
+
+			// TODO: Destroy after render, not before, especially given the asynchronous promise chains and render
+			// scheduling.
+			state.widgetKeys.forEach((key) => {
+				if (!includes(currentWidgetKeys, key)) {
+					// TODO: It follows that any registered widget instances should override their destroy() method, as
+					// destruction would prevent them from being reused. Alternatively we could communicate
+					// destroyability through the registry.
+					//
+					// Also, upon destruction factories should revert to creating a new instance. And if a factory
+					// always returns the same instance then the above applies.
+					state.handles.get(key).destroy();
+				}
+			});
 		});
 }
 
-function updateWidgets(
+interface UpdateResult {
+	currentWidgetKeys: Key[];
+	newWidgetsInVNodes: WidgetInVNode[];
+	vNodes: FlatVNodeChildren;
+}
+
+function updateNodes(
 	registry: ReadOnlyRegistry,
 	state: RenderState,
 	parentKey: Key,
 	counter: Counter,
-	append: SceneWidget[]
-): Promise<WidgetLike[]> {
+	nodes: SceneNode[]
+): Promise<UpdateResult> {
 	interface Child {
+		currentWidgetKeys?: Key[];
 		key: Key;
-		widget: WidgetLike;
+		newWidgetsInVNodes?: WidgetInVNode[];
+		text?: string;
+		vNode?: VNode;
+		widget?: WidgetLike;
 	}
-	const children: (Promise<Child> | Child)[] = append.map(({ widget: value }) => {
-		const key = state.widgetKeys.get(value) || { value };
-		if (!state.widgetKeys.has(value)) {
-			state.widgetKeys.set(value, key);
-		}
 
-		const widget = state.widgets.get(key);
-		if (widget) {
-			return { key, widget };
-		}
+	const children: (Promise<Child> | Child)[] = nodes.map((node, index) => {
+		if (isSceneWidget(node)) {
+			const { widget: value } = node;
+			const key = state.widgetKeys.get(value) || { value };
+			if (!state.widgetKeys.has(value)) {
+				state.widgetKeys.set(value, key);
+			}
 
-		return registry.getWidget(value).then((widget) => {
-			state.widgets.set(key, widget);
-			state.handles.set(key, {
-				destroy() {
-					widget.destroy();
-					state.widgetKeys.delete(key.value);
-				}
+			// TODO: Support nested children?
+
+			const widget = state.widgets.get(key);
+			if (widget) {
+				return { key, widget };
+			}
+
+			return registry.getWidget(value).then((widget) => {
+				state.widgets.set(key, widget);
+				state.handles.set(key, {
+					destroy() {
+						widget.destroy();
+						state.widgetKeys.delete(key.value);
+					}
+				});
+				return { key, widget };
 			});
-			return { key, widget };
-		});
+		}
+		else if (isSceneElement(node)) {
+			counter.incr();
+			const { key } = counter;
+			// TODO: Compare against previous VNode to avoid rerendering, but need to take into account children
+
+			if (!node.children) {
+				return {
+					key,
+					vNode: h(node.tagName)
+				};
+			}
+
+			return updateNodes(registry, state, key, counter.level(), node.children)
+				.then(({ currentWidgetKeys, vNodes, newWidgetsInVNodes }) => {
+					const vNode = h(node.tagName, vNodes);
+					for (
+						let i = newWidgetsInVNodes.length - 1;
+						i >= 0 && newWidgetsInVNodes[i].siblings === vNodes;
+						i--
+					) {
+						newWidgetsInVNodes[i].siblings = vNode.children!;
+					}
+
+					return {
+						currentWidgetKeys,
+						key,
+						newWidgetsInVNodes,
+						vNode
+					};
+				});
+		}
+		else {
+			counter.incr();
+			const { key } = counter;
+			return {
+				key,
+				text: node
+			};
+		}
 	});
 
 	return Promise.all(children)
 		.then((children) => {
-			const newKeys = children.map(({ key }) => key);
-			const previousKeys = state.childrenKeys.get(parentKey);
-			for (const key of previousKeys) {
-				if (!includes(newKeys, key)) {
-					// TODO: It follows that any registered widget instances should override their destroy() method, as
-					// destruction would prevent them from being reused. Alternatively we could communicate destroyability through
-					// the registry.
-					//
-					// Also, upon destruction factories should revert to creating a new instance. And if a factory always returns
-					// the same instance then the above applies.
-					state.handles.get(key).destroy();
-				}
-			}
+			const result: UpdateResult = {
+				currentWidgetKeys: [],
+				newWidgetsInVNodes: [],
+				vNodes: new Array(children.length)
+			};
 
-			return children.map(({ widget }) => widget);
+			children.forEach((child, index) => {
+				const {
+					currentWidgetKeys,
+					key,
+					newWidgetsInVNodes,
+					text,
+					vNode,
+					widget
+				} = child;
+
+				if (currentWidgetKeys) {
+					result.currentWidgetKeys = result.currentWidgetKeys.concat(currentWidgetKeys);
+				}
+				if (newWidgetsInVNodes) {
+					result.newWidgetsInVNodes = result.newWidgetsInVNodes.concat(newWidgetsInVNodes);
+				}
+
+				if (vNode) {
+					result.vNodes[index] = vNode;
+				}
+				else if (widget) {
+					result.currentWidgetKeys.push(key);
+					result.newWidgetsInVNodes.push({
+						index,
+						siblings: result.vNodes,
+						widget
+					});
+				}
+				else {
+					result.vNodes[index] = text!;
+				}
+			});
+
+			return result;
 		});
 }

--- a/src/lib/sceneManagement.ts
+++ b/src/lib/sceneManagement.ts
@@ -1,8 +1,10 @@
 import { Handle } from 'dojo-core/interfaces';
+import { includes } from 'dojo-shim/array';
 import Map from 'dojo-shim/Map';
 import Promise from 'dojo-shim/Promise';
 import WeakMap from 'dojo-shim/WeakMap';
 import { createProjector, Projector } from 'dojo-widgets/projector';
+import { List } from 'immutable';
 
 import {
 	Identifier,
@@ -36,6 +38,7 @@ interface Counter {
 
 interface RenderState {
 	root: Element;
+	children: WeakMap<Key<any>, Key<any>[]>;
 	handles: WeakMap<Key<any>, Handle>;
 	projectorKeys: Map<number, Key<number>>;
 	projectors: WeakMap<Key<number>, Projector>;
@@ -52,6 +55,7 @@ export function render(registry: ReadOnlyRegistry, root: Element, tree: SceneEle
 
 	const state = renderState.get(registry) || {
 		root,
+		children: new WeakMap<Key<any>, Key<any>[]>(),
 		handles: new WeakMap<Key<any>, Handle>(),
 		projectorKeys: new Map<number, Key<number>>(),
 		projectors: new WeakMap<Key<number>, Projector>(),
@@ -97,6 +101,7 @@ function update(
 	const projector = state.projectors.get(projectorKey) || createProjector({ root: state.root });
 	if (!state.projectors.has(projectorKey)) {
 		state.projectors.set(projectorKey, projector);
+		state.children.set(projectorKey, []);
 		state.handles.set(projectorKey, {
 			destroy() {
 				state.projectorKeys.delete(projectorKey.value);
@@ -104,7 +109,7 @@ function update(
 		});
 	}
 
-	return updateProjectorChildren(registry, state, counter, projector, tree.append)
+	return updateProjectorChildren(registry, state, counter, projectorKey, projector, tree.append)
 		.then(() => {
 			projector.attach();
 		});
@@ -114,28 +119,53 @@ function updateProjectorChildren(
 	registry: ReadOnlyRegistry,
 	state: RenderState,
 	counter: Counter,
+	projectorKey: Key<number>,
 	projector: Projector,
 	append: SceneWidget[]
 ): Promise<void> {
-	return Promise.all(
-		append.map(({ widget: id }) => registry.getWidget(id))
-	).then((widgets) => {
-		for (const widget of widgets) {
-			const { id } = widget;
-			const key = state.widgetKeys.get(id) || { value: id };
-			if (!state.widgetKeys.has(id)) {
-				state.widgetKeys.set(id, key);
-			}
+	interface Child {
+		key: Key<Identifier>;
+		widget: WidgetLike;
+	}
+	const children: (Promise<Child> | Child)[] = append.map(({ widget: value }) => {
+		const key = state.widgetKeys.get(value) || { value };
+		if (!state.widgetKeys.has(value)) {
+			state.widgetKeys.set(value, key);
+		}
 
-			// TODO: Implement diffing…
+		const widget = state.widgets.get(key);
+		if (widget) {
+			return { key, widget };
+		}
+
+		return registry.getWidget(value).then((widget) => {
 			state.widgets.set(key, widget);
-			const handle = projector.append(widget);
 			state.handles.set(key, {
 				destroy() {
-					handle.destroy();
+					widget.destroy();
 					state.widgetKeys.delete(key.value);
 				}
 			});
-		}
+			return { key, widget };
+		});
 	});
+
+	return Promise.all(children)
+		.then((children) => {
+			const newKeys = children.map(({ key }) => key);
+			const previousKeys = state.children.get(projectorKey);
+			for (const key of previousKeys) {
+				if (!includes(newKeys, key)) {
+					// TODO: It follows that any registered widget instances should override their destroy() method, as
+					// destruction would prevent them from being reused. Alternatively we could communicate destroyability through
+					// the registry.
+					//
+					// Also, upon destruction factories should revert to creating a new instance. And if a factory always returns
+					// the same instance then the above applies.
+					state.handles.get(key).destroy();
+				}
+			}
+
+			projector.children = List(children.map(({ widget }) => widget));
+		});
 }

--- a/src/lib/sceneManagement.ts
+++ b/src/lib/sceneManagement.ts
@@ -197,18 +197,24 @@ function update(
 			}
 			else if (isSceneElement(node)) {
 				counter.incr();
-				// TODO: Compare against previous VNode to avoid rerendering, but need to take into account children
-				// const { key } = counter;
+				// FIXME: Reuse previous key if (for the same value) it describes a VNode with the same tagName and
+				// properties.
+				const { key } = counter;
 
-				const vNode = h(node.tagName);
-				siblings.push(vNode);
+				const vnode = h(node.tagName, { key });
+				siblings.push(vnode);
+
 				if (node.children) {
-					processing.push([ vNode.children!, counter.level(), node.children ]);
+					processing.push([ vnode.children!, counter.level(), node.children ]);
 				}
 			}
 			else {
-				const vNode = h('', node);
-				siblings.push(vNode);
+				counter.incr();
+				// FIXME: Reuse previous key if (for the same value) it describes a VNode with the same text value.
+				const { key } = counter;
+
+				const vnode = h('', { key }, node);
+				siblings.push(vnode);
 			}
 		}
 	}

--- a/src/lib/sceneManagement.ts
+++ b/src/lib/sceneManagement.ts
@@ -1,0 +1,141 @@
+import { Handle } from 'dojo-core/interfaces';
+import Map from 'dojo-shim/Map';
+import Promise from 'dojo-shim/Promise';
+import WeakMap from 'dojo-shim/WeakMap';
+import { createProjector, Projector } from 'dojo-widgets/projector';
+
+import {
+	Identifier,
+	ReadOnlyRegistry,
+	WidgetLike
+} from '../createApp';
+
+export type SceneElement = SceneProjector | SceneWidget;
+
+export interface SceneProjector {
+	projector: true;
+	append: SceneWidget[];
+}
+
+function isSceneProjector(element: any): element is SceneProjector {
+	return element.projector === true;
+}
+
+export interface SceneWidget {
+	widget: Identifier;
+}
+
+interface Key<T> {
+	value: T;
+}
+
+// FIXME: Each level in the tree needs its own counter, then combine them to generate a unique string…
+interface Counter {
+	value: number;
+}
+
+interface RenderState {
+	root: Element;
+	handles: WeakMap<Key<any>, Handle>;
+	projectorKeys: Map<number, Key<number>>;
+	projectors: WeakMap<Key<number>, Projector>;
+	widgetKeys: Map<Identifier, Key<Identifier>>;
+	widgets: WeakMap<Key<Identifier>, WidgetLike>;
+}
+
+const renderState = new WeakMap<ReadOnlyRegistry, RenderState>();
+
+export function render(registry: ReadOnlyRegistry, root: Element, tree: SceneElement) {
+	if (!isSceneProjector(tree)) {
+		return Promise.reject(new Error('Tree must start with a SceneProjector for now, sorry'));
+	}
+
+	const state = renderState.get(registry) || {
+		root,
+		handles: new WeakMap<Key<any>, Handle>(),
+		projectorKeys: new Map<number, Key<number>>(),
+		projectors: new WeakMap<Key<number>, Projector>(),
+		widgetKeys: new Map<Identifier, Key<Identifier>>(),
+		widgets: new WeakMap<Key<Identifier>, WidgetLike>()
+	};
+	if (!renderState.has(registry)) {
+		renderState.set(registry, state);
+	}
+
+	return update(registry, state, { value: 0 }, tree)
+		.then(() => {
+			return {
+				destroy() {
+					state.projectorKeys.forEach((key) => {
+						if (state.handles.has(key)) {
+							state.handles.get(key).destroy();
+						}
+					});
+					state.widgetKeys.forEach((key) => {
+						if (state.handles.has(key)) {
+							state.handles.get(key).destroy();
+						}
+					});
+				}
+			};
+		});
+}
+
+function update(
+	registry: ReadOnlyRegistry,
+	state: RenderState,
+	counter: Counter,
+	tree: SceneProjector
+): Promise<void> {
+	const projectorId = counter.value++;
+	const projectorKey = state.projectorKeys.get(projectorId) || { value: projectorId };
+	if (!state.projectorKeys.has(projectorId)) {
+		state.projectorKeys.set(projectorId, projectorKey);
+	}
+
+	// TODO: Check if projector is different (once more options are supported)
+	const projector = state.projectors.get(projectorKey) || createProjector({ root: state.root });
+	if (!state.projectors.has(projectorKey)) {
+		state.projectors.set(projectorKey, projector);
+		state.handles.set(projectorKey, {
+			destroy() {
+				state.projectorKeys.delete(projectorKey.value);
+			}
+		});
+	}
+
+	return updateProjectorChildren(registry, state, counter, projector, tree.append)
+		.then(() => {
+			projector.attach();
+		});
+}
+
+function updateProjectorChildren(
+	registry: ReadOnlyRegistry,
+	state: RenderState,
+	counter: Counter,
+	projector: Projector,
+	append: SceneWidget[]
+): Promise<void> {
+	return Promise.all(
+		append.map(({ widget: id }) => registry.getWidget(id))
+	).then((widgets) => {
+		for (const widget of widgets) {
+			const { id } = widget;
+			const key = state.widgetKeys.get(id) || { value: id };
+			if (!state.widgetKeys.has(id)) {
+				state.widgetKeys.set(id, key);
+			}
+
+			// TODO: Implement diffing…
+			state.widgets.set(key, widget);
+			const handle = projector.append(widget);
+			state.handles.set(key, {
+				destroy() {
+					handle.destroy();
+					state.widgetKeys.delete(key.value);
+				}
+			});
+		}
+	});
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		"moduleResolution": "classic"
 	},
 	"include": [
+		"./examples/**/*.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts",
 		"./typings/index.d.ts"


### PR DESCRIPTION
Widget definitions cannot carry information as to where they need to be rendered (https://github.com/dojo/app/issues/84#issuecomment-255359483, https://github.com/dojo/app/issues/30#issuecomment-255380712). Interestingly the current implementation of the declarative DSL takes a two stage approach: extract registration elements, and render widgets. This PR is a proof of concept for generalizing the widget rendering in the declarative DSL.

A "scene" is a multiply rooted graph. It contains express elements, text nodes and widgets. There should be only one scene for a given HTML element and scenes must not be nested. Scenes can be re-rendered by passing a new graph.

Scenes are rendered using a Maquette `Projector`, rather than `createProjector` from `dojo-widgets`. Different projections are attached for the non-widget `VNode`s and well as for each (non-child) widget. Where possible widgets are preserved when scenes are re-rendered. Widgets are destroyed however when they disappear from the scene.

Scene graphs could be generated via declarative markup, POJO or programmatically. Template hierarchies could be compiled to a scene graph if we want to avoid code repetition. This is not something `App` has to concern itself with though.

Fallout:
- `App` allows widget instances to be registered. The POC destroys them when they disappear from the scene. Either it shouldn't, or only indestructible instances should be registered
- Widget factories cache the instance they created. They should create new instances once the cached instance is destroyed
- The `app-projector` element is gone. I don't think we'll miss scoping a `stateFrom` to a particular projector, but we do need a way of enabling animations
- Perhaps we want to support `app-scene` elements that can be realized. Default scene, and scenes with unique IDs
- `App#realize()` should be removed. `app-scene` can be processed by `extractRegistrationElements`
- `App#start()` (https://github.com/dojo/app/pull/76) should render scenes
- Need to add methods for re-rendering scenes with new graphs

Notes:
- I didn't think very hard about the word "scene", I just overhead it at our last f2f. Explanations as to why it's the right term or suggestions for better terms are welcome!
- Currently there is only a single scene for the entire App, but I can see an implementation where you register scenes into different locations of a scaffolding document
- You cannot currently specify element properties or widget children
- Keys for elements and text nodes are not yet retained between renders, even if the node is likely the same (children aside)

Example:
- Run `grunt dev`
- Start an HTTP server
- The example will be in `_build/examples/index.html`
- Open dev tools, then run `renderFoo()`, `renderBar()`, `renderAll()` to change scenes and `clearInterval(interval)`  to stop the timestamp from changing
