### PR TITLE
Add @types migration.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "tslint": "^3.15.1",
     "typescript": "~2.0.3",
     "@types/node": "^6.0.46",
-    "@types/chai": "~3.4.0"
+    "@types/chai": "~3.4.0",
+    "@types/es6-shim": "~0.31.0",
+    "@types/grunt": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.6",
     "tslint": "^3.15.1",
-    "typescript": "~2.0.3"
+    "typescript": "~2.0.3",
+    "@types/node": "^6.0.46",
+    "@types/chai": "~3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "codecov.io": "0.1.6",
     "dojo-actions": ">=2.0.0-alpha.8",
+    "dojo-interfaces": "^2.0.0-alpha.3",
     "dojo-loader": ">=2.0.0-beta.7",
     "dojo-routing": "^2.0.0-alpha.6",
     "dojo-stores": "^2.0.0-alpha.1",

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -1,11 +1,11 @@
 import { Action } from 'dojo-actions/createAction';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
-import { EventedListener, EventedListenersMap } from 'dojo-compose/mixins/createEvented';
-import { ObservableState, State } from 'dojo-compose/mixins/createStateful';
-import { Handle } from 'dojo-core/interfaces';
+import { ObservableState } from 'dojo-compose/bases/createStateful';
 import IdentityRegistry from 'dojo-core/IdentityRegistry';
 import { assign } from 'dojo-core/lang';
 import { PausableHandle } from 'dojo-core/on';
+import { EventedListener, EventedListenersMap, State } from 'dojo-interfaces/bases';
+import { Handle } from 'dojo-interfaces/core';
 import { Router, StartOptions as RouterStartOptions } from 'dojo-routing/createRouter';
 import { Context } from 'dojo-routing/interfaces';
 import Promise from 'dojo-shim/Promise';
@@ -79,7 +79,7 @@ export interface WidgetFactoryOptions {
 	/**
 	 * Listeners that should be attached when the widget is created.
 	 */
-	listeners?: EventedListenersMap;
+	listeners?: EventedListenersMap<any>;
 
 	/**
 	 * Provides access to read-only registries for actions, stores and widgets.
@@ -258,7 +258,7 @@ export interface WidgetDefinition extends ItemDefinition<WidgetFactory, WidgetLi
 /**
  * A listener for widgets, as used in definitions. May be an identifier for an action or an actual event listener.
  */
-export type WidgetListener = Identifier | EventedListener<any>;
+export type WidgetListener = Identifier | EventedListener<any, any>;
 
 export type WidgetListenerOrArray = WidgetListener | WidgetListener[];
 

--- a/src/lib/InstanceRegistry.ts
+++ b/src/lib/InstanceRegistry.ts
@@ -1,4 +1,4 @@
-import { Handle } from 'dojo-core/interfaces';
+import { Handle } from 'dojo-interfaces/core';
 import WeakMap from 'dojo-shim/WeakMap';
 
 import {

--- a/src/lib/factories.ts
+++ b/src/lib/factories.ts
@@ -1,4 +1,4 @@
-import { EventedListenersMap } from 'dojo-compose/mixins/createEvented';
+import { EventedListenersMap } from 'dojo-interfaces/bases';
 import { assign } from 'dojo-core/lang';
 import Promise from 'dojo-shim/Promise';
 
@@ -231,7 +231,7 @@ export function makeWidgetFactory(definition: WidgetDefinition, resolveMid: Reso
 			resolveStore(registry, definition)
 		]).then(([_factory, _listeners, _store]) => {
 			const factory = <WidgetFactory> _factory;
-			const listeners = <EventedListenersMap> _listeners;
+			const listeners = <EventedListenersMap<any>> _listeners;
 			const store = <StoreLike> _store || defaultWidgetStore;
 
 			if (listeners) {

--- a/src/lib/moduleResolver.ts
+++ b/src/lib/moduleResolver.ts
@@ -1,6 +1,7 @@
 import Promise from 'dojo-shim/Promise';
 import Symbol from 'dojo-shim/Symbol';
-
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 /**
  * Internal interface to asynchronously resolve a module by its identifier.
  */

--- a/src/lib/realizeCustomElements.ts
+++ b/src/lib/realizeCustomElements.ts
@@ -1,5 +1,5 @@
-import { EventedListenersMap } from 'dojo-compose/mixins/createEvented';
-import { Handle } from 'dojo-core/interfaces';
+import { EventedListenersMap } from 'dojo-interfaces/bases';
+import { Handle } from 'dojo-interfaces/core';
 import { from as arrayFrom } from 'dojo-shim/array';
 import Promise from 'dojo-shim/Promise';
 import Set from 'dojo-shim/Set';
@@ -164,12 +164,12 @@ interface JsonOptions {
 
 interface Options {
 	id?: string;
-	readonly listeners?: EventedListenersMap;
+	readonly listeners?: EventedListenersMap<any>;
 	registryProvider: RegistryProvider;
 	readonly stateFrom?: StoreLike;
 }
 
-function resolveListeners(registry: ReadOnlyRegistry, element: Element): null | Promise<EventedListenersMap> {
+function resolveListeners(registry: ReadOnlyRegistry, element: Element): null | Promise<EventedListenersMap<any>> {
 	const str = element.getAttribute('data-listeners');
 	if (!str) {
 		return null;
@@ -333,7 +333,7 @@ export default function realizeCustomElements(
 							projectorStateFrom
 						]).then(([_factory, _listeners, _options, _store, projectorStore]) => {
 							const factory: WidgetFactory = _factory;
-							const listeners: EventedListenersMap = _listeners;
+							const listeners: EventedListenersMap<any> = _listeners;
 							const options: WidgetFactoryOptions = _options;
 							// `data-state-from` store of the element takes precedence, then of the projector, then
 							// the application's default widget store.

--- a/src/lib/resolveListenersMap.ts
+++ b/src/lib/resolveListenersMap.ts
@@ -1,4 +1,5 @@
-import { EventedListener, EventedListenersMap, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
+import { EventedListener, EventedListenersMap } from 'dojo-interfaces/bases';
+import { EventTargettedObject } from 'dojo-interfaces/core';
 import Promise from 'dojo-shim/Promise';
 
 import {
@@ -29,9 +30,9 @@ function withoutPromises<T>(mixed: MixedResults<T>): mixed is T[][] & MixedResul
 function resolveListeners(
 	registry: ReadOnlyRegistry,
 	ref: WidgetListenerOrArray
-): ResolvedListeners<EventedListener<TargettedEventObject>> {
+): ResolvedListeners<EventedListener<any, EventTargettedObject<any>>> {
 	if (Array.isArray(ref)) {
-		const mixed: MixedResults<EventedListener<TargettedEventObject>> = [];
+		const mixed: MixedResults<EventedListener<any, EventTargettedObject<any>>> = [];
 		for (const item of ref) {
 			const result = resolveListeners(registry, item);
 			if (carriesValue(result)) {
@@ -43,7 +44,7 @@ function resolveListeners(
 			}
 		}
 
-		const flattened: EventedListener<TargettedEventObject>[] = [];
+		const flattened: EventedListener<any, EventTargettedObject<any>>[] = [];
 		if (withoutPromises(mixed)) {
 			return [flattened.concat(...mixed), undefined];
 		}
@@ -56,7 +57,7 @@ function resolveListeners(
 	}
 
 	if (typeof ref !== 'string') {
-		return [ [ <EventedListener<TargettedEventObject>> ref ], undefined ];
+		return [ [ <EventedListener<any, EventTargettedObject<any>>> ref ], undefined ];
 	}
 
 	return [
@@ -65,12 +66,12 @@ function resolveListeners(
 	];
 }
 
-export default function resolveListenersMap(registry: ReadOnlyRegistry, listeners?: WidgetListenersMap): null | Promise<EventedListenersMap> {
+export default function resolveListenersMap(registry: ReadOnlyRegistry, listeners?: WidgetListenersMap): null | Promise<EventedListenersMap<any>> {
 	if (!listeners) {
 		return null;
 	}
 
-	const map: EventedListenersMap = {};
+	const map: any = {};
 	const eventTypes = Object.keys(listeners);
 	return eventTypes.reduce((promise, eventType) => {
 		const result = resolveListeners(registry, listeners[eventType]);

--- a/tests/unit/createApp.ts
+++ b/tests/unit/createApp.ts
@@ -18,6 +18,8 @@ import {
 } from '../support/createApp';
 import stubDom from '../support/stubDom';
 import { defer } from '../support/util';
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 const { toAbsMid } = require;
 

--- a/tests/unit/createApp/actions.ts
+++ b/tests/unit/createApp/actions.ts
@@ -1,6 +1,8 @@
 import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 import createApp, {
 	ActionFactoryOptions,

--- a/tests/unit/createApp/customElements.ts
+++ b/tests/unit/createApp/customElements.ts
@@ -10,6 +10,8 @@ import {
 	rejects,
 	strictEqual
 } from '../../support/createApp';
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 const { toAbsMid } = require;
 

--- a/tests/unit/createApp/extractRegistrationElements.ts
+++ b/tests/unit/createApp/extractRegistrationElements.ts
@@ -4,6 +4,8 @@ import createWidget from 'dojo-widgets/createWidget';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createRouter from 'dojo-routing/createRouter';
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 import createApp, {
 	ActionFactoryOptions,

--- a/tests/unit/createApp/stores.ts
+++ b/tests/unit/createApp/stores.ts
@@ -18,6 +18,8 @@ import {
 import { defer } from '../../support/util';
 
 const { toAbsMid } = require;
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 registerSuite({
 	name: 'createApp (stores)',

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -54,7 +54,7 @@ registerSuite({
 
 			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
 				return app.getWidget('foo').then((widget) => {
-					assert.isObject(widget);
+					assert.equal(widget.tagName, 'div');
 				});
 			});
 		},
@@ -67,7 +67,7 @@ registerSuite({
 
 			return defaultWidgetStore.add({id: 'foo', type: 'custom-element'}).then(() => {
 				return app.getWidget('foo').then((widget) => {
-					assert.isObject(widget);
+					assert.equal(widget.tagName, 'div');
 				});
 			});
 		},

--- a/tests/unit/createApp/widgets.ts
+++ b/tests/unit/createApp/widgets.ts
@@ -26,6 +26,8 @@ import {
 	strictEqual
 } from '../../support/createApp';
 import { defer } from '../../support/util';
+import { Require } from 'dojo-interfaces/loader';
+declare const require: Require;
 
 const { toAbsMid } = require;
 

--- a/typings.json
+++ b/typings.json
@@ -9,7 +9,6 @@
 		"maquette": "npm:maquette"
 	},
 	"devDependencies": {
-		"chai": "registry:npm/chai#3.5.0+20160415060238",
 		"glob": "registry:npm/glob#6.0.0+20160211003958",
 		"immutable": "npm:immutable",
 		"sinon": "registry:npm/sinon#1.16.0+20160427193336",
@@ -17,14 +16,12 @@
 	},
 	"globalDevDependencies": {
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo-loader": "npm:dojo-loader",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
 		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
 		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#92fcf688c0982c1107fca278de52e4bfe23bd8af",
+		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"node": "github:dojo/typings/custom/node/node.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
 	}
 }

--- a/typings.json
+++ b/typings.json
@@ -18,8 +18,6 @@
 		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
-		"gruntjs": "registry:dt/gruntjs#0.4.0+20160316171810",
 		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
 		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"


### PR DESCRIPTION
**Type:** feature

**Description:** 
This PR adds @types migration for `dojo/app`. It is based on https://github.com/dojo/app/pull/89 which does `dojo-interfaces` migration. There's one unit test failing which is caused by out-dated dependency: `dojo-store`. To address this, we need to:
* Land all opened `dojo-store` PRs: https://github.com/dojo/stores/pulls and create a release for it
* Land this PR
* Land @maier49's work: https://github.com/dojo/app/compare/master...maier49:integrate-stores-mvp


**Related Issue:** #90 

Please review this checklist before submitting your PR:

* [x] There is a related issue
* [X] All contributors have signed a CLA
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] The code passes the CI tests
* [ ] Unit or Functional tests are included in the PR
* [x] The PR increases or maintains the overall unit test coverage percentage
* [x] The code is ready to be merged
